### PR TITLE
Feat/brand loader and refactor

### DIFF
--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -10,6 +10,7 @@
         "parcel-bundler": "^1.12.3",
         "parcel-plugin-bundle-visualiser": "1.2.0",
         "parcel-plugin-url-loader": "^1.3.1",
+        "preact": "next",
         "typescript": "^3.5.2"
     },
     "name": "@giphy/js-brand",
@@ -27,7 +28,6 @@
     },
     "source": true,
     "dependencies": {
-        "emotion": "10.0.9",
-        "preact": "^8.4.2"
+        "emotion": "10.0.9"
     }
 }

--- a/packages/brand/public/color-guide.tsx
+++ b/packages/brand/public/color-guide.tsx
@@ -1,10 +1,10 @@
 import { h } from 'preact'
 import * as colors from '../src/colors'
 import { css, cx } from 'emotion'
-import { SubheaderSmall } from '../src/typography'
+import { css as typographtCss } from '../src/typography'
 
 const colorsCss = cx(
-    SubheaderSmall,
+    typographtCss.subheaderSmall,
     css`
         display: flex;
         flex-wrap: wrap;
@@ -25,8 +25,8 @@ const colorCss = css`
 `
 
 const Color = ({ color, name }) => (
-    <div class={item}>
-        <div class={colorCss} style={{ backgroundColor: color }} />
+    <div className={item}>
+        <div className={colorCss} style={{ backgroundColor: color }} />
         <div>{name}</div>
         <div>{color}</div>
     </div>
@@ -39,7 +39,7 @@ const Colors = Object.keys(colors).map(color =>
 const ColorsGuide = () => (
     <div>
         <h2>Colors</h2>
-        <div class={colorsCss}>{Colors}</div>
+        <div className={colorsCss}>{Colors}</div>
     </div>
 )
 

--- a/packages/brand/public/header.tsx
+++ b/packages/brand/public/header.tsx
@@ -27,6 +27,6 @@ const header = css`
     }
 `
 
-const Header = ({ children }) => <div class={header}>{children}</div>
+const Header = ({ children }: { children?: ChildNode }) => <div className={header}>{children}</div>
 
 export default Header

--- a/packages/brand/public/icons-guide.tsx
+++ b/packages/brand/public/icons-guide.tsx
@@ -4,7 +4,7 @@ import { adPill } from '../src/icons'
 const IconsGuide = () => (
     <div>
         <h2>Icons</h2>
-        <div class={adPill} width="36" height="36" />
+        <div className={adPill} style={{ width: 36, height: 36 }} />
     </div>
 )
 

--- a/packages/brand/public/index.tsx
+++ b/packages/brand/public/index.tsx
@@ -2,6 +2,7 @@ import { h, render } from 'preact'
 import Header from './header'
 import IconsGuide from './icons-guide'
 import ColorsGuide from './color-guide'
+import loader from '../src/loader'
 
 declare const module: any
 
@@ -14,6 +15,7 @@ render(
         </Header>
         <ColorsGuide />
         <IconsGuide />
+        <div className={loader} />
     </div>,
     mountNode,
     mountNode.lastChild as Element,

--- a/packages/brand/public/index.tsx
+++ b/packages/brand/public/index.tsx
@@ -2,7 +2,7 @@ import { h, render } from 'preact'
 import Header from './header'
 import IconsGuide from './icons-guide'
 import ColorsGuide from './color-guide'
-import loader from '../src/loader'
+import LoaderGuide from './loader-guide'
 
 declare const module: any
 
@@ -15,7 +15,7 @@ render(
         </Header>
         <ColorsGuide />
         <IconsGuide />
-        <div className={loader} />
+        <LoaderGuide />
     </div>,
     mountNode,
     mountNode.lastChild as Element,

--- a/packages/brand/public/loader-guide.tsx
+++ b/packages/brand/public/loader-guide.tsx
@@ -1,0 +1,17 @@
+import { h } from 'preact'
+import loader from '../src/loader'
+
+const LoaderGuide = () => (
+    <div>
+        <h2>Loader</h2>
+        <div className={loader} style={{ margin: 0 }}>
+            <div />
+            <div />
+            <div />
+            <div />
+            <div />
+        </div>
+    </div>
+)
+
+export default LoaderGuide

--- a/packages/brand/src/loader.ts
+++ b/packages/brand/src/loader.ts
@@ -1,37 +1,49 @@
 import { css, keyframes } from 'emotion'
-import { giphyBlack, giphyGreen, giphyWhite } from './colors'
+import { giphyBlue, giphyGreen, giphyPurple, giphyRed, giphyYellow } from './colors'
 
-const loaderBar = keyframes`
-    0% {
-        transform: translateX(-20%);
-    }
-    100% {
-        transform: translateX(120%);
-    }
+const bouncer = keyframes`
+     to {
+    transform: scale(1.75) translateY(-20px);
+  }
 `
+const loaderHeight = 37
 const loader = css`
-    box-sizing: content-box;
-    width: 100%;
-    padding: 30px 0 0;
-    height: 10px;
-    overflow: hidden;
-    position: relative;
-    list-style: none;
-
-    &:before {
-        animation: ${loaderBar} 2s ease-in-out 0s infinite;
-        box-shadow: 10px 10px ${giphyBlack}, 20px 10px #007f4c, 30px 10px #00bf73, 40px 10px ${giphyGreen},
-            50px 10px ${giphyGreen}, 60px 10px ${giphyGreen}, 70px 10px ${giphyGreen}, 80px 10px ${giphyGreen},
-            90px 10px ${giphyGreen}, 100px 10px ${giphyGreen}, 110px 10px ${giphyWhite};
-        bottom: 10px;
-        content: '';
-        display: block;
+    display: flex;
+    align-items: center;
+    height: ${loaderHeight}px;
+    padding-top: 15px;
+    margin: 0 auto;
+    text-align: center;
+    width: 200px;
+    animation: pulse 0.8s ease-in-out 0s infinite alternate backwards;
+    div {
+        display: inline-block;
         height: 10px;
-        margin-right: 55px;
-        position: absolute;
-        right: 100%;
-        width: 100%;
+        width: 10px;
+        margin: ${loaderHeight}px 10px 10px 10px;
+        position: relative;
+        box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
+        animation: ${bouncer} cubic-bezier(0.455, 0.03, 0.515, 0.955) 0.75s infinite alternate;
+        &:nth-child(5n + 1) {
+            background: ${giphyGreen};
+            animation-delay: 0;
+        }
+        &:nth-child(5n + 2) {
+            background: ${giphyBlue};
+            animation-delay: calc(0s + (0.1s * 1));
+        }
+        &:nth-child(5n + 3) {
+            background: ${giphyPurple};
+            animation-delay: calc(0s + (0.1s * 2));
+        }
+        &:nth-child(5n + 4) {
+            background: ${giphyRed};
+            animation-delay: calc(0s + (0.1s * 3));
+        }
+        &:nth-child(5n + 5) {
+            background: ${giphyYellow};
+            animation-delay: calc(0s + (0.1s * 4));
+        }
     }
 `
-
 export default loader

--- a/packages/brand/yarn.lock
+++ b/packages/brand/yarn.lock
@@ -4375,10 +4375,10 @@ posthtml@^0.11.2, posthtml@^0.11.3:
     posthtml-parser "^0.3.3"
     posthtml-render "^1.1.0"
 
-preact@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
-  integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==
+preact@next:
+  version "10.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.0.0-beta.3.tgz#dabd0628d941f9e7908f68bb008e012ddff1b28f"
+  integrity sha512-JDeA+CVFBlv+r+v/tScG8hzOcOedXfBLUA5IhStqpfc7rPGY3T85pdlu4aGo2tV0AoZzQfO4LTnKkQEnKJ3UxQ==
 
 prelude-ls@~1.1.2:
   version "1.1.2"

--- a/packages/components/src/components/loader.tsx
+++ b/packages/components/src/components/loader.tsx
@@ -1,4 +1,15 @@
 import { h } from 'preact'
 import { loader } from '@giphy/js-brand'
+import { cx } from 'emotion'
 
-export default () => <div class={loader} />
+// trying to share css from brand, but this has an element structure
+// so it's ugly. will probably move the css in here
+export default ({ className = '' }: { className?: string }) => (
+    <div className={cx(loader, className)}>
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+    </div>
+)

--- a/packages/react-components/public/test.html
+++ b/packages/react-components/public/test.html
@@ -14,7 +14,7 @@
         }
     </style>
     <body>
-        <h3 id="banner">Giphy JS Components</h3>
+        <h3 id="banner">Giphy React Components</h3>
         <div id="react-target"></div>
     </body>
     <script src="./index.tsx"></script>

--- a/packages/react-components/src/components/loader.tsx
+++ b/packages/react-components/src/components/loader.tsx
@@ -1,4 +1,15 @@
 import React from 'react'
 import { loader } from '@giphy/js-brand'
+import { cx } from 'emotion'
 
-export default () => <div className={loader} />
+// trying to share css from brand, but this has an element structure
+// so it's ugly. will probably move the css in here
+export default ({ className = '' }: { className?: string }) => (
+    <div className={cx(loader, className)}>
+        <div />
+        <div />
+        <div />
+        <div />
+        <div />
+    </div>
+)


### PR DESCRIPTION
- squares replaces snake loader
- preact is a devdep in brand, only used in dev mode
- upgrade preact to `next`
