### PR TITLE
WEB-5114: SDK testing feedback

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -153,8 +153,9 @@ import { renderGif } from '@giphy/js-components'
 
 | property        | type                                                                 | description                                                     |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
-| onGifHover      | `(gif: IGif, e: Event) => void`                                      | fired on desktop when hovered for                               |
-| onGifVisible    | `(gif: IGif, e: Event) => void`                                      | fired every time the gif is show                                |
-| onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect &#124; DOMRect) => void` | fired once after the gif loads and when it's completely in view |
+| onGifHover      | `(gif: IGif, e: Event) => void`                                      | fired on desktop when hovered over                              |
+| onGifUnhover    | `(gif: IGif, e: Event) => void`                                      | fired on desktop on mouse out, given an active hover event      |
+| onGifVisible    | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired every time the gif is shown                               |
+| onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect | DOMRect) => void`      | fired once after the gif loads and when it's completely in view |
 | onGifClick      | `(gif: IGif, e: Event) => void`                                      | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: Event) => void`                                      | fired when the gif is right clicked                             |

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -16,9 +16,10 @@ Use `renderGrid(props, target)` to render a grid to a target element
 import { renderGrid } from '@giphy/js-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
-// use @giphy/js-fetch-api to fetch gifs
+// create a GIPHY API client with your api key
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls (`offset` is handled by the grid)
+// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls
+// create a fetch gifs function that takes an `offset` parameter
 const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 // render a grid
 const targetEl = window.document.getElementById('giphy-grid')
@@ -45,9 +46,10 @@ import { throttle } from 'throttle-debounce'
 import { renderGrid } from '@giphy/js-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
-// create a GiphyFetch with your api key
+// create a GIPHY API client with your api key
 const gf = new GiphyFetch('your api key')
-// create a fetch gifs function that takes an offset
+
+// create a fetch gifs function that takes an `offset` parameter
 // this will allow the grid to paginate as the user scrolls
 const fetchGifs = (offset) => {
     // use whatever end point you want,
@@ -62,16 +64,19 @@ const makeGrid = (targetEl) => {
         return renderGrid(
             {
                 width: innerWidth,
-                fetchGifs,
-                columns: width < 500 ? 2 : 3,
+                columns: window.innerWidth < 500 ? 2 : 3,
                 gutter: 6,
+                fetchGifs,
             },
             targetEl
         )
     }
+    // register callback to window resize event
     const resizeRender = throttle(500, render)
     window.addEventListener('resize', resizeRender, false)
+    // render the grid
     const el = render()
+    // return a removal function
     return () => {
         el.parentNode.removeChild(el)
         window.removeEventListener('resize', resizeRender, false)
@@ -79,10 +84,10 @@ const makeGrid = (targetEl) => {
 }
 
 // Instantiate
-const grid = makeGrid(document.querySelector('.grid'))
+const removeGrid = makeGrid(window.document.getElementById('giphy-grid'))
 
 // To remove
-grid.remove()
+removeGrid()
 ```
 
 ## Carousel

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -10,7 +10,7 @@ A lightweight set of components, focused on ease-of-use and performance.
 
 Use `renderGrid(props, target)` to render a grid to a target element
 
-### Bare Bones Example
+### Bare Bones TypeScript Example
 
 ```typescript
 import { renderGrid } from '@giphy/js-components'
@@ -40,7 +40,7 @@ _renderGrid options_
 | [Gif Events](#gif-events)             | \*                                       | \*                    | see below                                                                |
 | [API Fetch Events](#api-fetch-events) | \*                                       | \*                    | see below                                                                |
 
-### Thorough Example
+### Thorough TypeScript Example
 
 ```typescript
 import { throttle } from 'throttle-debounce'
@@ -103,6 +103,8 @@ _renderCarousel options_
 | [Gif Events](#gif-events)             | \*                                       | \*        | see below                                                                |
 | [API Fetch Events](#api-fetch-events) | \*                                       | \*        | see below                                                                |
 
+_TypeScript example_
+
 ```typescript
 import { renderCarousel } from '@giphy/js-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
@@ -136,8 +138,9 @@ _Gif props_
 | backgroundColor           | `string` | random giphy color | The background of the gif before it loads |
 | [Gif Events](#gif-events) | \*       | \*                 | see below                                 |
 
+_TypeScript example_
 
-```javascript
+```typescript
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { renderGif } from '@giphy/js-components'
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -156,6 +156,8 @@ import { renderGif } from '@giphy/js-components'
 
 ### Gif Events
 
+Subscribe to Gif component events by passing callbacks as the following options.
+
 | property        | type                                                                 | description                                                     |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
 | onGifHover      | `(gif: IGif, e: Event) => void`                                      | fired on desktop when hovered over                              |
@@ -165,7 +167,23 @@ import { renderGif } from '@giphy/js-components'
 | onGifClick      | `(gif: IGif, e: Event) => void`                                      | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: Event) => void`                                      | fired when the gif is right clicked                             |
 
+_TypeScript example: overriding `onGifClick` event in a grid_
+
+```typescript
+import { IGif } from '@giphy/js-types'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+import { renderGrid } from '@giphy/js-components'
+
+const gf = new GiphyFetch('your api key')
+renderGrid({
+    fetchGifs: (offset: number) => gf.trending({ offset, limit: 10 }),
+    onGifClick: (gif: IGif, e: Event) => { e.preventDefault(); console.log(gif) }
+}, window.document.getElementById('giphy-grid'))
+```
+
 ### API Fetch Events
+
+Subscribe to API fetch events by passing callbacks as the following options.
 
 | property        | type                                                                 | description                                                     |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
@@ -173,3 +191,17 @@ import { renderGif } from '@giphy/js-components'
 | onPage          | `(page: number) => void`                                             | fired by paginator on each fetch, provides page number          |
 | onGifsFetched   | `(gifs: IGif[]) => void`                                             | fired by component on each fetch, provides list of all gifs     |
 | onFetchError    | `(e: Error) => void`                                                 | fired by component on fetch error                               |
+
+_TypeScript example: carousel pagination_
+
+```typescript
+import { IGif } from '@giphy/js-types'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+import { renderCarousel } from '@giphy/js-components'
+
+const gf = new GiphyFetch('your api key')
+renderCarousel({
+    fetchGifs: (offset: number) => gf.trending({ offset, limit: 10 }),
+    onPage: (page: number) => { console.log(page) }
+}, window.document.getElementById('giphy-carousel'))
+```

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -123,6 +123,32 @@ renderCarousel(
 )
 ```
 
+## Gif
+
+_Gif props_
+
+| _prop_                    | _type_   | _default_          | _description_                             |
+| ------------------------- | -------- | ------------------ | ----------------------------------------- |
+| gif                       | `IGif`   | undefined          | The gif to display                        |
+| width                     | `number` | undefined          | The width of the gif                      |
+| backgroundColor           | `string` | random giphy color | The background of the gif before it loads |
+| [Gif Events](#gif-events) | \*       | \*                 | see below                                 |
+
+
+```javascript
+import { GiphyFetch } from '@giphy/js-fetch-api'
+import { renderGif } from '@giphy/js-components'
+
+(async () => {
+    const gf = new GiphyFetch('your api key')
+    const { data: gif } = await gf.gif('fpXxIjftmkk9y')
+    renderGif({
+        gif,
+        width: parseInt(gif['images']['original']['width'])
+    }, window.document.getElementById('giphy-gif'))
+})()
+```
+
 ### Gif Events
 
 | property        | type                                                                 | description                                                     |

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -30,14 +30,15 @@ renderGrid({ width: 800, columns: 3, gutter: 6, fetchGifs }, targetEl)
 
 _renderGrid options_
 
-| _prop_                    | _type_                                   | _default_             | _description_                                                            |
-| ------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
-| width                     | `number`                                 | document width or 800 | The width of the grid                                                    |
-| columns                   | `number`                                 | 3                     | The number of columns in the grid                                        |
-| gutter                    | `number`                                 | 6                     | The space between columns and rows                                       |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| targetEl                  |  `HTMLElement`                           | undefined             | Target element into which the grid is rendered                           |
-| [Gif Events](#gif-events) | \*                                       | \*                    | see below                                                                |
+| _prop_                                | _type_                                   | _default_             | _description_                                                            |
+| ------------------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
+| width                                 | `number`                                 | document width or 800 | The width of the grid                                                    |
+| columns                               | `number`                                 | 3                     | The number of columns in the grid                                        |
+| gutter                                | `number`                                 | 6                     | The space between columns and rows                                       |
+| fetchGifs                             | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| targetEl                              |  `HTMLElement`                           | undefined             | Target element into which the grid is rendered                           |
+| [Gif Events](#gif-events)             | \*                                       | \*                    | see below                                                                |
+| [API Fetch Events](#api-fetch-events) | \*                                       | \*                    | see below                                                                |
 
 ### Thorough Example
 
@@ -94,12 +95,13 @@ removeGrid()
 
 _renderCarousel options_
 
-| property                  | type                                     | default   | description                                                              |
-| ------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| gifHeight                 | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
+| property                              | type                                     | default   | description                                                              |
+| ------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
+| gifHeight                             | `number`                                 | undefined | The height of the gifs and the carousel                                  |
+| gutter                                | `number`                                 | 6         | The space between columns and rows                                       |
+| fetchGifs                             | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| [Gif Events](#gif-events)             | \*                                       | \*        | see below                                                                |
+| [API Fetch Events](#api-fetch-events) | \*                                       | \*        | see below                                                                |
 
 ```typescript
 import { renderCarousel } from '@giphy/js-components'
@@ -159,3 +161,12 @@ import { renderGif } from '@giphy/js-components'
 | onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect | DOMRect) => void`      | fired once after the gif loads and when it's completely in view |
 | onGifClick      | `(gif: IGif, e: Event) => void`                                      | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: Event) => void`                                      | fired when the gif is right clicked                             |
+
+### API Fetch Events
+
+| property        | type                                                                 | description                                                     |
+| --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
+| onFetch         | `(gifs: IGif[]) => void`                                             | fired by paginator on each fetch, provides list of gifs fetched |
+| onPage          | `(page: number) => void`                                             | fired by paginator on each fetch, provides page number          |
+| onGifsFetched   | `(gifs: IGif[]) => void`                                             | fired by component on each fetch, provides list of all gifs     |
+| onFetchError    | `(e: Error) => void`                                                 | fired by component on fetch error                               |

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -12,15 +12,15 @@ Use `renderGrid(props, target)` to render a grid to a target element
 
 ### Bare Bones Example
 
-```javascript
+```typescript
 import { renderGrid } from '@giphy/js-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
 // create a GIPHY API client with your api key
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls
 // create a fetch gifs function that takes an `offset` parameter
-const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
+// this will allow the grid to paginate as the user scrolls
+const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 // render a grid
 const targetEl = window.document.getElementById('giphy-grid')
 renderGrid({ width: 800, columns: 3, gutter: 6, fetchGifs }, targetEl)
@@ -33,15 +33,15 @@ _renderGrid options_
 | _prop_                    | _type_                                   | _default_             | _description_                                                            |
 | ------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
 | width                     | `number`                                 | document width or 800 | The width of the grid                                                    |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | columns                   | `number`                                 | 3                     | The number of columns in the grid                                        |
 | gutter                    | `number`                                 | 6                     | The space between columns and rows                                       |
+| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | targetEl                  |  `HTMLElement`                           | undefined             | Target element into which the grid is rendered                           |
 | [Gif Events](#gif-events) | \*                                       | \*                    | see below                                                                |
 
 ### Thorough Example
 
-```javascript
+```typescript
 import { throttle } from 'throttle-debounce'
 import { renderGrid } from '@giphy/js-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
@@ -51,14 +51,14 @@ const gf = new GiphyFetch('your api key')
 
 // create a fetch gifs function that takes an `offset` parameter
 // this will allow the grid to paginate as the user scrolls
-const fetchGifs = (offset) => {
+const fetchGifs = (offset: number) => {
     // use whatever end point you want,
     // but be sure to pass offset to paginate correctly
     return gf.trending({ offset, limit: 25 })
 }
 
 // Creating a grid with window resizing and remove-ability
-const makeGrid = (targetEl) => {
+const makeGrid = (targetEl: HTMLElement) => {
     const render = () => {
         // here is the @giphy/js-components import
         return renderGrid(
@@ -97,8 +97,8 @@ _renderCarousel options_
 | property                  | type                                     | default   | description                                                              |
 | ------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
 | gifHeight                 | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
+| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
 
 ```typescript
@@ -108,19 +108,19 @@ import { GiphyFetch } from '@giphy/js-fetch-api'
 // create a GIPHY API client with your api key
 const gf = new GiphyFetch('your api key')
 
-// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls
-// create a fetch gifs function that takes an `offset` parameter
-const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
+export const vanillaJSCarousel = (mountNode: HTMLElement) => {
+    renderCarousel(
+        {
+            gifHeight: 200,
+            fetchGifs: (offset: number) => gf.trending({ offset }),
+            gutter: 6,
+            onGifClick: (gif: IGif) => window.open(gif.url),
+        },
+        mountNode
+    )
+}
 
-renderCarousel(
-    {
-        gifHeight: 200,
-        gutter: 6,
-        onGifClick: (gif) => window.open(gif.url),
-        fetchGifs
-    },
-    window.document.getElementById('giphy-carousel')
-)
+vanillaJSCarousel(window.document.getElementById('giphy-carousel'))
 ```
 
 ## Gif
@@ -155,7 +155,7 @@ import { renderGif } from '@giphy/js-components'
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
 | onGifHover      | `(gif: IGif, e: Event) => void`                                      | fired on desktop when hovered over                              |
 | onGifUnhover    | `(gif: IGif, e: Event) => void`                                      | fired on desktop on mouse out, given an active hover event      |
-| onGifVisible    | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired every time the gif is shown                               |
+| onGifVisible    | `(gif: IGif, e: Event) => void`                                      | fired every time the gif is shown                               |
 | onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect | DOMRect) => void`      | fired once after the gif loads and when it's completely in view |
 | onGifClick      | `(gif: IGif, e: Event) => void`                                      | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: Event) => void`                                      | fired when the gif is right clicked                             |

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -103,19 +103,24 @@ _renderCarousel options_
 
 ```typescript
 import { renderCarousel } from '@giphy/js-components'
+import { GiphyFetch } from '@giphy/js-fetch-api'
 
-// Creating a grid with window resizing and remove-ability
-export const vanillaJSCarousel = (mountNode: HTMLElement) => {
-    renderCarousel(
-        {
-            gifHeight: 200,
-            fetchGifs: (offset: number) => gf.trending({ offset }),
-            gutter: 6,
-            onGifClick: (gif: IGif) => window.open(gif.url),
-        },
-        mountNode
-    )
-}
+// create a GIPHY API client with your api key
+const gf = new GiphyFetch('your api key')
+
+// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls
+// create a fetch gifs function that takes an `offset` parameter
+const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
+
+renderCarousel(
+    {
+        gifHeight: 200,
+        gutter: 6,
+        onGifClick: (gif) => window.open(gif.url),
+        fetchGifs
+    },
+    window.document.getElementById('giphy-carousel')
+)
 ```
 
 ### Gif Events

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -12,30 +12,35 @@ Use `renderGrid(props, target)` to render a grid to a target element
 
 ### Bare Bones Example
 
-```typescript
+```javascript
+import { renderGrid } from '@giphy/js-components'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time as the user scrolls (offset is handled by the grid)
-const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
+// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls (`offset` is handled by the grid)
+const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 // render a grid
-renderGrid({ width: 800, fetchGifs }, targetEl)
+const targetEl = window.document.getElementById('giphy-grid')
+renderGrid({ width: 800, columns: 3, gutter: 6, fetchGifs }, targetEl)
 ```
 
 <!-- The grid uses [bricks.js]() to render a grid with fixed width items. -->
 
 _renderGrid options_
 
-| _prop_                    | _type_                                   | _default_ | _description_                                                            |
-| ------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| width                     | `number`                                 | undefined | The width of the grid                                                    |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| columns                   | `number`                                 | 3         | The number of columns in the grid                                        |
-| gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
-| [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
+| _prop_                    | _type_                                   | _default_             | _description_                                                            |
+| ------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
+| width                     | `number`                                 | document width or 800 | The width of the grid                                                    |
+| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| columns                   | `number`                                 | 3                     | The number of columns in the grid                                        |
+| gutter                    | `number`                                 | 6                     | The space between columns and rows                                       |
+| targetEl                  |  `HTMLElement`                           | undefined             | Target element into which the grid is rendered                           |
+| [Gif Events](#gif-events) | \*                                       | \*                    | see below                                                                |
 
 ### Thorough Example
 
-```typescript
+```javascript
 import { throttle } from 'throttle-debounce'
 import { renderGrid } from '@giphy/js-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
@@ -44,14 +49,14 @@ import { GiphyFetch } from '@giphy/js-fetch-api'
 const gf = new GiphyFetch('your api key')
 // create a fetch gifs function that takes an offset
 // this will allow the grid to paginate as the user scrolls
-const fetchGifs = (offset: number) => {
+const fetchGifs = (offset) => {
     // use whatever end point you want,
     // but be sure to pass offset to paginate correctly
     return gf.trending({ offset, limit: 25 })
 }
 
 // Creating a grid with window resizing and remove-ability
-const makeGrid = (targetEl: HTMLElement) => {
+const makeGrid = (targetEl) => {
     const render = () => {
         // here is the @giphy/js-components import
         return renderGrid(

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -1,11 +1,11 @@
-import { gifPaginator, GifsResult } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
 import { debounce } from 'throttle-debounce'
 import { IGif, IUser } from '@giphy/js-types'
 import { getGifWidth } from '@giphy/js-util'
 import { css, cx } from 'emotion'
 import { Component, h } from 'preact'
 import Observer from '../util/observer'
-import Gif, { EventProps } from './gif'
+import Gif, { EventProps as GifEventProps } from './gif'
 import FetchError from './fetch-error'
 
 const carouselCss = css`
@@ -38,9 +38,7 @@ type Props = {
     gifHeight: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
-    onGifsFetched?: (gifs: IGif[]) => void
-    onGifsFetchError?: (e: Error) => void
-} & EventProps
+} & GifEventProps & FetchEventProps
 const defaultProps = Object.freeze({
     gifHeight: 200,
     gutter: 6,
@@ -88,8 +86,8 @@ class Carousel extends Component<Props, State> {
                 gifs = await this.paginator()
             } catch (error) {
                 this.setState({ isFetching: false, isError: true })
-                const { onGifsFetchError } = this.props
-                if (onGifsFetchError) onGifsFetchError(error)
+                const { onFetchError } = this.props
+                if (onFetchError) onFetchError(error)
             }
             if (gifs) {
                 if (existingGifs.length === gifs.length) {

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -112,6 +112,7 @@ class Carousel extends Component<Props, State> {
             className = Carousel.className,
             onGifClick,
             onGifHover,
+            onGifUnhover,
             onGifSeen,
             user,
         }: Props,
@@ -138,6 +139,7 @@ class Carousel extends Component<Props, State> {
                             width={gifWidth}
                             onGifClick={onGifClick}
                             onGifHover={onGifHover}
+                            onGifUnhover={onGifUnhover}
                             onGifSeen={onGifSeen}
                             onGifVisible={onGifVisible}
                             onGifRightClick={onGifRightClick}

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -1,4 +1,4 @@
-import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventProps as FetchEventProps } from '@giphy/js-fetch-api'
 import { debounce } from 'throttle-debounce'
 import { IGif, IUser } from '@giphy/js-types'
 import { getGifWidth } from '@giphy/js-util'
@@ -69,7 +69,8 @@ class Carousel extends Component<Props, State> {
     constructor(props: Props) {
         super(props)
         // create a paginator
-        this.paginator = gifPaginator(props.fetchGifs)
+        const { fetchGifs, onFetch, onPage } = props
+        this.paginator = gifPaginator({ fetchGifs, onFetch, onPage })
     }
     componentDidMount() {
         this.onFetch()

--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -119,7 +119,7 @@ class Gif extends Component<Props, State> {
         const { gif, onGifUnhover } = this.props
         const { isHovered } = this.state
         clearTimeout(this.hoverTimeout)
-        if(isHovered) {
+        if (isHovered) {
             this.unhoverTimeout = setTimeout(() => {
                 this.setState({ isHovered: false })
                 onGifUnhover && onGifUnhover(gif, e)

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -135,6 +135,7 @@ class Grid extends Component<Props, State> {
             className = Grid.className,
             onGifClick,
             onGifHover,
+            onGifUnhover,
             onGifSeen,
             user,
         }: Props,
@@ -151,6 +152,7 @@ class Grid extends Component<Props, State> {
                             width={gifWidth}
                             onGifClick={onGifClick}
                             onGifHover={onGifHover}
+                            onGifUnhover={onGifUnhover}
                             onGifSeen={onGifSeen}
                             onGifVisible={onGifVisible}
                             onGifRightClick={onGifRightClick}

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -18,7 +18,13 @@ type Props = {
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void
 } & EventProps
-const defaultProps = Object.freeze({ gutter: 6, user: {} })
+
+const defaultProps = Object.freeze({
+    columns: 3,
+    gutter: 6,
+    width: (typeof window !== 'undefined') ? window.innerWidth : 800,
+    user: {},
+})
 
 type State = {
     gifWidth: number

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -4,7 +4,7 @@ import Gif, { EventProps as GifEventProps } from './gif'
 import Bricks from 'bricks.js'
 import Observer from '../util/observer'
 import { IGif, IUser } from '@giphy/js-types'
-import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventProps as FetchEventProps } from '@giphy/js-fetch-api'
 import Loader from './loader'
 import FetchError from './fetch-error'
 
@@ -59,7 +59,8 @@ class Grid extends Component<Props, State> {
     }
     constructor(props: Props) {
         super(props)
-        this.paginator = gifPaginator(props.fetchGifs)
+        const { fetchGifs, onFetch, onPage } = props
+        this.paginator = gifPaginator({ fetchGifs, onFetch, onPage })
     }
     setBricks() {
         const { columns, gutter } = this.props

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -1,10 +1,10 @@
 import { h, Component } from 'preact'
 import { debounce } from 'throttle-debounce'
-import Gif, { EventProps } from './gif'
+import Gif, { EventProps as GifEventProps } from './gif'
 import Bricks from 'bricks.js'
 import Observer from '../util/observer'
 import { IGif, IUser } from '@giphy/js-types'
-import { GifsResult, gifPaginator } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
 import Loader from './loader'
 import FetchError from './fetch-error'
 
@@ -15,9 +15,7 @@ type Props = {
     columns: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
-    onGifsFetched?: (gifs: IGif[]) => void
-    onGifsFetchError?: (e: Error) => void
-} & EventProps
+} & GifEventProps & FetchEventProps
 
 const defaultProps = Object.freeze({
     columns: 3,
@@ -113,8 +111,8 @@ class Grid extends Component<Props, State> {
                 gifs = await this.paginator()
             } catch (error) {
                 this.setState({ isFetching: false, isError: true })
-                const { onGifsFetchError } = this.props
-                if (onGifsFetchError) onGifsFetchError(error)
+                const { onFetchError } = this.props
+                if (onFetchError) onFetchError(error)
             }
             if (gifs) {
                 if (existingGifs.length === gifs.length) {

--- a/packages/fetch-api/src/event-types.ts
+++ b/packages/fetch-api/src/event-types.ts
@@ -1,6 +1,12 @@
 import { IGif } from '@giphy/js-types'
 
-export interface EventTypes {
-    onGifsFetched?: (gifs: IGif[]) => void
-    onFetchError?: (e: Error) => void
+export type onFetch = (gifs: IGif[]) => void
+export type onPage = (page: number) => void
+export type onFetchError = (e: Error) => void
+
+export interface EventProps {
+    onFetch?: onFetch // used by fetch client
+    onPage?: onPage // used by fetch client
+    onGifsFetched?: onFetch // used by components
+    onFetchError?: onFetchError // used by components?
 }

--- a/packages/fetch-api/src/event-types.ts
+++ b/packages/fetch-api/src/event-types.ts
@@ -8,5 +8,5 @@ export interface EventProps {
     onFetch?: onFetch // used by fetch client
     onPage?: onPage // used by fetch client
     onGifsFetched?: onFetch // used by components
-    onFetchError?: onFetchError // used by components?
+    onFetchError?: onFetchError // used by components
 }

--- a/packages/fetch-api/src/event-types.ts
+++ b/packages/fetch-api/src/event-types.ts
@@ -1,0 +1,6 @@
+import { IGif } from '@giphy/js-types'
+
+export interface EventTypes {
+    onGifsFetched?: (gifs: IGif[]) => void
+    onFetchError?: (e: Error) => void
+}

--- a/packages/fetch-api/src/index.ts
+++ b/packages/fetch-api/src/index.ts
@@ -1,4 +1,5 @@
 export { default as GiphyFetch } from './api'
+export { EventTypes } from './event-types'
 export * from './option-types'
 export * from './result-types'
 export { gifPaginator } from './paginator'

--- a/packages/fetch-api/src/index.ts
+++ b/packages/fetch-api/src/index.ts
@@ -1,5 +1,5 @@
 export { default as GiphyFetch } from './api'
-export { EventTypes } from './event-types'
+export * from './event-types'
 export * from './option-types'
 export * from './result-types'
 export { gifPaginator } from './paginator'

--- a/packages/fetch-api/src/paginator.ts
+++ b/packages/fetch-api/src/paginator.ts
@@ -20,10 +20,13 @@ export const gifPaginator = (
     let gifIds: (string | number)[] = []
     let offset = 0
     let page = 0
+    let isDoneFetching = false
     return async () => {
+        if (isDoneFetching) return [...gifs]
         const result = await fetchGifs(offset)
         const { pagination, data: newGifs } = result
         offset = pagination.count + pagination.offset
+        isDoneFetching = offset === pagination.total_count
         page += 1
         newGifs.forEach(gif => {
             const { id } = gif

--- a/packages/fetch-api/src/paginator.ts
+++ b/packages/fetch-api/src/paginator.ts
@@ -1,18 +1,30 @@
 import { IGif } from '@giphy/js-types'
 import { GifsResult } from './result-types'
+import { onFetch, onPage } from './event-types'
 
 /**
  * @hidden
  */
-export const gifPaginator = (fetchGifs: (offset: number) => Promise<GifsResult>) => {
+export const gifPaginator = (
+{
+    fetchGifs,
+    onFetch,
+    onPage
+}: {
+    fetchGifs: (offset: number) => Promise<GifsResult>
+    onFetch?: onFetch
+    onPage?: onPage
+}) => {
     let gifs: IGif[] = []
     // for deduping
     let gifIds: (string | number)[] = []
     let offset = 0
+    let page = 0
     return async () => {
         const result = await fetchGifs(offset)
         const { pagination, data: newGifs } = result
         offset = pagination.count + pagination.offset
+        page += 1
         newGifs.forEach(gif => {
             const { id } = gif
             if (!gifIds.includes(id)) {
@@ -21,6 +33,8 @@ export const gifPaginator = (fetchGifs: (offset: number) => Promise<GifsResult>)
                 gifIds.push(id)
             }
         })
+        if (onFetch) onFetch(newGifs)
+        if (onPage) onPage(page)
         return [...gifs]
     }
 }

--- a/packages/fetch-api/src/paginator.ts
+++ b/packages/fetch-api/src/paginator.ts
@@ -1,19 +1,18 @@
 import { IGif } from '@giphy/js-types'
 import { GifsResult } from './result-types'
-import { onFetch, onPage } from './event-types'
+import { onFetch as onFetchType, onPage as onPageType } from './event-types'
 
 /**
  * @hidden
  */
-export const gifPaginator = (
-{
+export const gifPaginator = ({
     fetchGifs,
     onFetch,
-    onPage
+    onPage,
 }: {
     fetchGifs: (offset: number) => Promise<GifsResult>
-    onFetch?: onFetch
-    onPage?: onPage
+    onFetch?: onFetchType
+    onPage?: onPageType
 }) => {
     let gifs: IGif[] = []
     // for deduping

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -10,14 +10,15 @@ React components, focused on ease-of-use and performance.
 
 ### Bare Bones Example
 
-```javascript
+```typescript
 import { Grid } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls (`offset` is handled by the grid)
-const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
+// create a fetch gifs function that takes an `offset` parameter
+// this will allow the grid to paginate as the user scrolls
+const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 // React Component
 <Grid width={800} columns={3} gutter={6} fetchGifs={fetchGifs} />
 ```
@@ -41,15 +42,16 @@ const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 | fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
 
-```javascript
+```typescript
 import { Carousel } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls
+
 // create a fetch gifs function that takes an `offset` parameter
-const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
+// this will allow the grid to paginate as the user scrolls
+const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 
 // React Component
 <Carousel gifHeight={200} gutter={6} fetchGifs={fetchGifs} />
@@ -66,7 +68,7 @@ _Gif props_
 | backgroundColor           | `string` | random giphy color | The background of the gif before it loads |
 | [Gif Events](#gif-events) | \*       | \*                 | see below                                 |
 
-```javascript
+```typescript
 import { Gif } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
@@ -82,8 +84,8 @@ const { data } = await gf.gif('fpXxIjftmkk9y')
 
 | _prop_          | _type_                                                               | _description_                                                   |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
-| onGifHover      | `(gif: IGif, e: Event) => void`                                      | fired on desktop when hovered over                              |
-| onGifUnhover    | `(gif: IGif, e: Event) => void`                                      | fired on desktop on mouse out, given an active hover event      |
+| onGifHover      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired on desktop when hovered over                              |
+| onGifUnhover    | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired on desktop on mouse out, given an active hover event      |
 | onGifVisible    | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired every time the gif is shown                               |
 | onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect | DOMRect) => void`      | fired once after the gif loads and when it's completely in view |
 | onGifClick      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is clicked                                   |

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -8,7 +8,7 @@ React components, focused on ease-of-use and performance.
 
 ## Grid
 
-### Bare Bones Example
+### Bare Bones Typescript Example
 
 ```typescript
 import { Grid } from '@giphy/react-components'
@@ -44,6 +44,8 @@ const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 | [Gif Events](#gif-events)             | \*                                       | \*        | see below                                                                |
 | [API Fetch Events](#api-fetch-events) | \*                                       | \*        | see below                                                                |
 
+_TypeScript example_
+
 ```typescript
 import { Carousel } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
@@ -69,6 +71,8 @@ _Gif props_
 | width                     | `number` | undefined          | The width of the gif                      |
 | backgroundColor           | `string` | random giphy color | The background of the gif before it loads |
 | [Gif Events](#gif-events) | \*       | \*                 | see below                                 |
+
+_TypeScript example_
 
 ```typescript
 import { Gif } from '@giphy/react-components'

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -10,26 +10,27 @@ React components, focused on ease-of-use and performance.
 
 ### Bare Bones Example
 
-```typescript
+```javascript
 import { Grid } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
+
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time as the user scrolls (offset is handled by the grid)
-const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
+// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls (`offset` is handled by the grid)
+const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 // React Component
-<Grid width={width} columns={3} gutter={6} fetchGifs={fetchGifs} />
+<Grid width={800} columns={3} gutter={6} fetchGifs={fetchGifs} />
 ```
 
 <!-- The grid uses [bricks.js]() to render a grid with fixed width items. -->
 
-| _prop_                    | _type_                                   | _default_ | _description_                                                            |
-| ------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| width                     | `number`                                 | undefined | The width of the grid                                                    |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| columns                   | `number`                                 | 3         | The number of columns in the grid                                        |
-| gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
-| [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
+| _prop_                    | _type_                                   | _default_             | _description_                                                            |
+| ------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
+| width                     | `number`                                 | document width or 800 | The width of the grid                                                    |
+| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| columns                   | `number`                                 | 3                     | The number of columns in the grid                                        |
+| gutter                    | `number`                                 | 6                     | The space between columns and rows                                       |
+| [Gif Events](#gif-events) | \*                                       | \*                    | see below                                                                |
 
 ## Carousel
 
@@ -40,14 +41,14 @@ const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 | gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
 | [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
 
-```typescript
+```javascript
 import { Carousel } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time as the user scrolls (offset is handled by the grid)
-const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
+// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls (`offset` is handled by the grid)
+const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 
 // React Component
 <Carousel gifHeight={200} gutter={6} fetchGifs={fetchGifs} />
@@ -64,13 +65,13 @@ _Gif props_
 | backgroundColor           | `string` | random giphy color | The background of the gif before it loads |
 | [Gif Events](#gif-events) | \*       | \*                 | see below                                 |
 
-```typescript
+```javascript
 import { Gif } from '@giphy/react-components'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time as the user scrolls (offset is handled by the grid)
+// fetch a GIF from the GIPHY API
 const { data } = await gf.gif('fpXxIjftmkk9y')
 // React Component
 <Gif gif={data} width={300} />

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -82,8 +82,9 @@ const { data } = await gf.gif('fpXxIjftmkk9y')
 
 | _prop_          | _type_                                                               | _description_                                                   |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
-| onGifHover      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired on desktop when hovered for                               |
-| onGifVisible    | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired every time the gif is show                                |
-| onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect &#124; DOMRect) => void` | fired once after the gif loads and when it's completely in view |
+| onGifHover      | `(gif: IGif, e: Event) => void`                                      | fired on desktop when hovered over                              |
+| onGifUnhover    | `(gif: IGif, e: Event) => void`                                      | fired on desktop on mouse out, given an active hover event      |
+| onGifVisible    | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired every time the gif is shown                               |
+| onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect | DOMRect) => void`      | fired once after the gif loads and when it's completely in view |
 | onGifClick      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is right clicked                             |

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -27,9 +27,9 @@ const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 | _prop_                    | _type_                                   | _default_             | _description_                                                            |
 | ------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
 | width                     | `number`                                 | document width or 800 | The width of the grid                                                    |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | columns                   | `number`                                 | 3                     | The number of columns in the grid                                        |
 | gutter                    | `number`                                 | 6                     | The space between columns and rows                                       |
+| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | [Gif Events](#gif-events) | \*                                       | \*                    | see below                                                                |
 
 ## Carousel
@@ -37,8 +37,8 @@ const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 | _prop_                    | _type_                                   | _default_ | _description_                                                            |
 | ------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
 | gifHeight                 | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
+| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
 
 ```javascript
@@ -47,7 +47,8 @@ import { GiphyFetch } from '@giphy/js-fetch-api'
 
 // use @giphy/js-fetch-api to fetch gifs
 const gf = new GiphyFetch('your api key')
-// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls (`offset` is handled by the grid)
+// fetch 10 gifs at a time from the GIPHY Trending API as the user scrolls
+// create a fetch gifs function that takes an `offset` parameter
 const fetchGifs = (offset) => gf.trending({ offset, limit: 10 })
 
 // React Component

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -25,22 +25,24 @@ const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 
 <!-- The grid uses [bricks.js]() to render a grid with fixed width items. -->
 
-| _prop_                    | _type_                                   | _default_             | _description_                                                            |
-| ------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
-| width                     | `number`                                 | document width or 800 | The width of the grid                                                    |
-| columns                   | `number`                                 | 3                     | The number of columns in the grid                                        |
-| gutter                    | `number`                                 | 6                     | The space between columns and rows                                       |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| [Gif Events](#gif-events) | \*                                       | \*                    | see below                                                                |
+| _prop_                                | _type_                                   | _default_             | _description_                                                            |
+| ------------------------------------- | ---------------------------------------- | --------------------- | ------------------------------------------------------------------------ |
+| width                                 | `number`                                 | document width or 800 | The width of the grid                                                    |
+| columns                               | `number`                                 | 3                     | The number of columns in the grid                                        |
+| gutter                                | `number`                                 | 6                     | The space between columns and rows                                       |
+| fetchGifs                             | `(offset:number) => Promise<GifsResult>` | undefined             | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| [Gif Events](#gif-events)             | \*                                       | \*                    | see below                                                                |
+| [API Fetch Events](#api-fetch-events) | \*                                       | \*                    | see below                                                                |
 
 ## Carousel
 
-| _prop_                    | _type_                                   | _default_ | _description_                                                            |
-| ------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| gifHeight                 | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| gutter                    | `number`                                 | 6         | The space between columns and rows                                       |
-| fetchGifs                 | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| [Gif Events](#gif-events) | \*                                       | \*        | see below                                                                |
+| _prop_                                | _type_                                   | _default_ | _description_                                                            |
+| ------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
+| gifHeight                             | `number`                                 | undefined | The height of the gifs and the carousel                                  |
+| gutter                                | `number`                                 | 6         | The space between columns and rows                                       |
+| fetchGifs                             | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| [Gif Events](#gif-events)             | \*                                       | \*        | see below                                                                |
+| [API Fetch Events](#api-fetch-events) | \*                                       | \*        | see below                                                                |
 
 ```typescript
 import { Carousel } from '@giphy/react-components'
@@ -90,3 +92,12 @@ const { data } = await gf.gif('fpXxIjftmkk9y')
 | onGifSeen       | `(gif: IGif, boundingClientRect: ClientRect | DOMRect) => void`      | fired once after the gif loads and when it's completely in view |
 | onGifClick      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is right clicked                             |
+
+### API Fetch Events
+
+| property        | type                                                                 | description                                                     |
+| --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
+| onFetch         | `(gifs: IGif[]) => void`                                             | fired by paginator on each fetch, provides list of gifs fetched |
+| onPage          | `(page: number) => void`                                             | fired by paginator on each fetch, provides page number          |
+| onGifsFetched   | `(gifs: IGif[]) => void`                                             | fired by component on each fetch, provides list of all gifs     |
+| onFetchError    | `(e: Error) => void`                                                 | fired by component on fetch error                               |

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -88,6 +88,8 @@ const { data } = await gf.gif('fpXxIjftmkk9y')
 
 ### Gif Events
 
+Subscribe to Gif component events by passing callbacks as the following props.
+
 | _prop_          | _type_                                                               | _description_                                                   |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
 | onGifHover      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired on desktop when hovered over                              |
@@ -97,7 +99,23 @@ const { data } = await gf.gif('fpXxIjftmkk9y')
 | onGifClick      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is right clicked                             |
 
+_TypeScript example: overriding `onGifClick` event in a grid_
+
+```typescript
+import { IGif } from '@giphy/js-types'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+import { Grid } from '@giphy/react-components'
+
+const gf = new GiphyFetch('your api key')
+<Grid
+    fetchGifs={(offset: number) => gf.trending({ offset, limit: 10 })}
+    onGifClick={(gif: IGif, e: Event) => { e.preventDefault(); console.log(gif) }}
+/>
+```
+
 ### API Fetch Events
+
+Subscribe to API fetch events by passing callbacks as the following props.
 
 | property        | type                                                                 | description                                                     |
 | --------------- | -------------------------------------------------------------------- | --------------------------------------------------------------- |
@@ -105,3 +123,17 @@ const { data } = await gf.gif('fpXxIjftmkk9y')
 | onPage          | `(page: number) => void`                                             | fired by paginator on each fetch, provides page number          |
 | onGifsFetched   | `(gifs: IGif[]) => void`                                             | fired by component on each fetch, provides list of all gifs     |
 | onFetchError    | `(e: Error) => void`                                                 | fired by component on fetch error                               |
+
+_TypeScript example: carousel pagination_
+
+```typescript
+import { IGif } from '@giphy/js-types'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+import { Carousel } from '@giphy/react-components'
+
+const gf = new GiphyFetch('your api key')
+<Carousel
+    fetchGifs={(offset: number) => gf.trending({ offset, limit: 10 })}
+    onPage={(page: number) => { console.log(page) }}
+/>
+```

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -116,6 +116,7 @@ class Carousel extends PureComponent<Props, State> {
             gutter,
             className = Carousel.className,
             onGifHover,
+            onGifUnhover,
             onGifSeen,
             onGifClick,
             user,
@@ -143,6 +144,7 @@ class Carousel extends PureComponent<Props, State> {
                             width={gifWidth}
                             onGifClick={onGifClick}
                             onGifHover={onGifHover}
+                            onGifUnhover={onGifUnhover}
                             onGifSeen={onGifSeen}
                             onGifVisible={onGifVisible}
                             onGifRightClick={onGifRightClick}

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -1,11 +1,11 @@
-import { gifPaginator, GifsResult } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
 import { debounce } from 'throttle-debounce'
 import { IGif, IUser } from '@giphy/js-types'
 import { getGifWidth } from '@giphy/js-util'
 import { css, cx } from 'emotion'
 import React, { PureComponent, ReactType } from 'react'
 import Observer from '../util/observer'
-import Gif, { EventProps, GifOverlayProps } from './gif'
+import Gif, { EventProps as GifEventProps, GifOverlayProps } from './gif'
 import FetchError from './fetch-error'
 
 const carouselCss = css`
@@ -44,10 +44,8 @@ type Props = {
     gifHeight: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
-    onGifsFetched?: (gifs: IGif[]) => void
-    onGifsFetchError?: (e: Error) => void
     overlay?: ReactType<GifOverlayProps>
-} & EventProps
+} & GifEventProps & FetchEventProps
 const defaultProps = Object.freeze({
     gifHeight: 200,
     gutter: 6,
@@ -93,8 +91,8 @@ class Carousel extends PureComponent<Props, State> {
                 gifs = await this.paginator()
             } catch (error) {
                 this.setState({ isFetching: false, isError: true })
-                const { onGifsFetchError } = this.props
-                if (onGifsFetchError) onGifsFetchError(error)
+                const { onFetchError } = this.props
+                if (onFetchError) onFetchError(error)
             }
             if (gifs) {
                 if (existingGifs.length === gifs.length) {

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -1,4 +1,4 @@
-import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventProps as FetchEventProps } from '@giphy/js-fetch-api'
 import { debounce } from 'throttle-debounce'
 import { IGif, IUser } from '@giphy/js-types'
 import { getGifWidth } from '@giphy/js-util'
@@ -74,7 +74,8 @@ class Carousel extends PureComponent<Props, State> {
     paginator: () => Promise<IGif[]>
     constructor(props: Props) {
         super(props)
-        this.paginator = gifPaginator(props.fetchGifs)
+        const { fetchGifs, onFetch, onPage } = props
+        this.paginator = gifPaginator({ fetchGifs, onFetch, onPage })
     }
     componentDidMount() {
         this.onFetch()

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -123,7 +123,7 @@ class Gif extends PureComponent<Props, State> {
         const { gif, onGifUnhover } = this.props
         const { isHovered } = this.state
         clearTimeout(this.hoverTimeout)
-        if(isHovered) {
+        if (isHovered) {
             this.unhoverTimeout = setTimeout(() => {
                 this.setState({ isHovered: false })
                 onGifUnhover && onGifUnhover(gif, e)

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -137,6 +137,7 @@ class Grid extends PureComponent<Props, State> {
             onGifRightClick,
             className = Grid.className,
             onGifHover,
+            onGifUnhover,
             onGifSeen,
             onGifClick,
             user,
@@ -154,6 +155,7 @@ class Grid extends PureComponent<Props, State> {
                             width={gifWidth}
                             onGifClick={onGifClick}
                             onGifHover={onGifHover}
+                            onGifUnhover={onGifUnhover}
                             onGifSeen={onGifSeen}
                             onGifVisible={onGifVisible}
                             onGifRightClick={onGifRightClick}

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -1,10 +1,10 @@
 import React, { PureComponent, ReactType } from 'react'
 import { debounce } from 'throttle-debounce'
-import Gif, { EventProps, GifOverlayProps } from './gif'
+import Gif, { EventProps as GifEventProps, GifOverlayProps } from './gif'
 import Bricks from 'bricks.js'
 import Observer from '../util/observer'
 import { IGif, IUser } from '@giphy/js-types'
-import { GifsResult, gifPaginator } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
 import Loader from './loader'
 import FetchError from './fetch-error'
 
@@ -15,10 +15,8 @@ type Props = {
     columns: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
-    onGifsFetched?: (gifs: IGif[]) => void
-    onGifsFetchError?: (e: Error) => void
     overlay?: ReactType<GifOverlayProps>
-} & EventProps
+} & GifEventProps & FetchEventProps
 
 const defaultProps = Object.freeze({
     columns: 3,
@@ -114,8 +112,8 @@ class Grid extends PureComponent<Props, State> {
                 gifs = await this.paginator()
             } catch (error) {
                 this.setState({ isFetching: false, isError: true })
-                const { onGifsFetchError } = this.props
-                if (onGifsFetchError) onGifsFetchError(error)
+                const { onFetchError } = this.props
+                if (onFetchError) onFetchError(error)
             }
             if (gifs) {
                 // if we've just fetched and we don't have

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -20,7 +20,12 @@ type Props = {
     overlay?: ReactType<GifOverlayProps>
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {} })
+const defaultProps = Object.freeze({
+    columns: 3,
+    gutter: 6,
+    width: (typeof window !== 'undefined') ? window.innerWidth : 800,
+    user: {},
+})
 
 type State = {
     gifWidth: number

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -16,8 +16,6 @@ type Props = {
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
     overlay?: ReactType<GifOverlayProps>
-    xonFetch: any
-    xonPage: any
 } & GifEventProps & FetchEventProps
 
 const defaultProps = Object.freeze({

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -4,7 +4,7 @@ import Gif, { EventProps as GifEventProps, GifOverlayProps } from './gif'
 import Bricks from 'bricks.js'
 import Observer from '../util/observer'
 import { IGif, IUser } from '@giphy/js-types'
-import { gifPaginator, GifsResult, EventTypes as FetchEventProps } from '@giphy/js-fetch-api'
+import { gifPaginator, GifsResult, EventProps as FetchEventProps } from '@giphy/js-fetch-api'
 import Loader from './loader'
 import FetchError from './fetch-error'
 
@@ -16,6 +16,8 @@ type Props = {
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
     overlay?: ReactType<GifOverlayProps>
+    xonFetch: any
+    xonPage: any
 } & GifEventProps & FetchEventProps
 
 const defaultProps = Object.freeze({
@@ -60,7 +62,8 @@ class Grid extends PureComponent<Props, State> {
     }
     constructor(props: Props) {
         super(props)
-        this.paginator = gifPaginator(props.fetchGifs)
+        const { fetchGifs, onFetch, onPage } = props
+        this.paginator = gifPaginator({ fetchGifs, onFetch, onPage })
     }
     setBricks() {
         const { columns, gutter } = this.props


### PR DESCRIPTION
- Documentation
    - Added documentation+example for Gif component to vanilla JS README
    - Fixed minor issues with code examples to make them copy/paste-able
    - Added example of overriding `onGifClick` event in a grid (common use case)
    - Call out that examples are in TypeScript

- Events
    - Added API fetch events: `onFetch`, `onPage`, `onGifsFetched`, `onError`, provided by `@giphy/js-fetch-api` in `packages/fetch-api/src/event-types.ts`
    - Added Gif component event: `onGifUnhover`, ensuring it only fires following an `onGifHover`

- Fixes
    - Bug: `gifPaginator` was performing one extraneous request after reaching the end of a result set
    - Copied error handling from Grid component to Carousel components

- Misc
    - Make Grid `width` optional, defaulting to document width if available, otherwise `800`
    - Added default `height` to Carousel component
    - Found and removed a couple unused vars (e.g. `numberOfGifs` in vanillajs carousel component)