### PR TITLE
feat(fetch-api): emoji

### DIFF
--- a/packages/fetch-api/public/index.tsx
+++ b/packages/fetch-api/public/index.tsx
@@ -1,6 +1,6 @@
 import { GiphyFetch } from '../src/api'
 
-const gf = new GiphyFetch('4OMJYpPoYwVpe')
+const gf = new GiphyFetch('sXpGFDGZs0Dv1mmNFvYaGUvYwKX0PWIh')
 
 const categories = async () => {
     try {
@@ -76,6 +76,15 @@ const random = async () => {
         console.error(`random`, error)
     }
 }
+
+const emoji = async () => {
+    try {
+        const result = await gf.emoji({ limit: 2 })
+        console.log(`emoji`, result)
+    } catch (error) {
+        console.error(`emoji`, error)
+    }
+}
 categories()
 search()
 gif()
@@ -86,3 +95,4 @@ subcategories()
 trending()
 random()
 related()
+emoji()

--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -124,6 +124,11 @@ describe('response parsing', () => {
         const { data } = await gf.related('12345')
         testDummyGif(data[0], 'GIF_RELATED')
     })
+    test('emoji', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
+        const { data } = await gf.emoji()
+        testDummyGif(data[0], 'EMOJI')
+    })
     test('error', async () => {
         fetchMock.mockResponses([JSON.stringify({}), { status: 400 }])
         try {

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -11,6 +11,7 @@ import {
     SubcategoriesOptions,
     MediaType,
     RelatedOptions,
+    PaginationOptions,
 } from './option-types'
 import { normalizeGifs, normalizeGif } from './normalize/gif'
 
@@ -70,6 +71,10 @@ export class GiphyFetch {
             return request(`gifs?${this.getQS({ ids: arg1.join(',') })}`, normalizeGifs) as Promise<GifsResult>
         }
         return request(`gifs/categories/${arg1}/${arg2}?${this.getQS()}`, normalizeGifs) as Promise<GifsResult>
+    }
+
+    emoji(options?: PaginationOptions): Promise<GifsResult> {
+        return request(`emoji?${this.getQS(options)}`, normalizeGifs, 'EMOJI') as Promise<GifsResult>
     }
 
     /**

--- a/packages/types/src/pingback-event.ts
+++ b/packages/types/src/pingback-event.ts
@@ -1,1 +1,9 @@
-export type PingbackEventType = 'GIF_TRENDING' | 'GIF_RELATED' | 'GIF_CHANNEL' | 'GIF_SEARCH' | 'GIF_EXPLORE' | ''
+export type PingbackEventType =
+    | 'GIF_TRENDING'
+    | 'GIF_RELATED'
+    | 'GIF_CHANNEL'
+    | 'GIF_SEARCH'
+    | 'EMOJI'
+    | 'TEXT_SEARCH'
+    | 'TEXT_TRENDING'
+    | ''


### PR DESCRIPTION
Add the emoji endpoint to the fetch-api. It doesn't support search, just returns all the emoji, therefore the only options are the `PaginationOptions`

Here is the emoji endpoint being used in a `Grid`:

<img width="972" alt="Screen Shot 2019-08-19 at 12 06 27 PM" src="https://user-images.githubusercontent.com/448767/63284843-1bd12200-c27a-11e9-84ea-6abf42db842a.png">
