### PR TITLE
Feat/fetch api text

### DIFF
--- a/packages/fetch-api/README.md
+++ b/packages/fetch-api/README.md
@@ -116,6 +116,24 @@ related(id: string, options?: RelatedOptions): Promise<GifsResult>
 const { data: gifs } = await gf.related('3oEjHGr1Fhz0kyv8Ig', { limit: 10 })
 ```
 
+## _emoji_
+
+Fetch emoji
+
+##### Signature:
+
+```typescript
+emoji(options?: PaginationOptions): Promise<GifsResult>
+```
+
+> Emoji Options: [Pagination Options](#pagination-options)
+
+##### Example:
+
+```typescript
+const { data: gifs } = await gf.emoji()
+```
+
 ## _random_
 
 Returns a random single GIF
@@ -190,8 +208,8 @@ Options: [Pagination Options](#pagination-options)
 
 ### Type Option
 
-| option | type   | description    | default |
-| :----- | :----- | :------------- | :-----: |
-| _type_ | string | gif or sticker |   gif   |
+| option | type   | description          | default |
+| :----- | :----- | :------------------- | :-----: |
+| _type_ | string | gif / sticker / text |   gif   |
 
 [lang]: https://developers.giphy.com/docs/#language-support

--- a/packages/fetch-api/README.md
+++ b/packages/fetch-api/README.md
@@ -17,7 +17,7 @@ const { data: gifs } = await gf.trending({ limit: 10 })
 
 [![Edit @giphy/js-fetch-api](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/20kmp3zp9r?fontsize=14)
 
-# Fetch GIFs and Stickers
+# Fetch GIFs, Stickers, and Animated Text
 
 ## _search_
 
@@ -118,7 +118,7 @@ const { data: gifs } = await gf.related('3oEjHGr1Fhz0kyv8Ig', { limit: 10 })
 
 ## _emoji_
 
-Fetch emoji
+Fetch emoji. Emoji are stickers from a currated channel. There's no search or trending emoji.
 
 ##### Signature:
 

--- a/packages/fetch-api/public/index.tsx
+++ b/packages/fetch-api/public/index.tsx
@@ -85,6 +85,24 @@ const emoji = async () => {
         console.error(`emoji`, error)
     }
 }
+
+const text = async () => {
+    try {
+        const result = await gf.search('pasta', { limit: 2, type: 'text' })
+        console.log(`text`, result)
+    } catch (error) {
+        console.error(`text`, error)
+    }
+}
+
+const textTrending = async () => {
+    try {
+        const result = await gf.trending({ limit: 2, type: 'text' })
+        console.log(`textTrending`, result)
+    } catch (error) {
+        console.error(`textTrending`, error)
+    }
+}
 categories()
 search()
 gif()
@@ -96,3 +114,5 @@ trending()
 random()
 related()
 emoji()
+text()
+textTrending()

--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -129,6 +129,16 @@ describe('response parsing', () => {
         const { data } = await gf.emoji()
         testDummyGif(data[0], 'EMOJI')
     })
+    test('text search', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
+        const { data } = await gf.search('pasta', { type: 'text' })
+        testDummyGif(data[0], 'TEXT_SEARCH')
+    })
+    test('text trending', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
+        const { data } = await gf.trending({ type: 'text' })
+        testDummyGif(data[0], 'TEXT_TRENDING')
+    })
     test('error', async () => {
         fetchMock.mockResponses([JSON.stringify({}), { status: 400 }])
         try {

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -82,9 +82,10 @@ export class GiphyFetch {
      * @param options: SearchOptions
      * @returns {Promise<GifsResult>}
      **/
-    search(term: string, options?: SearchOptions): Promise<GifsResult> {
+    search(term: string, options: SearchOptions = {}): Promise<GifsResult> {
         const qsParams = this.getQS({ ...options, ...{ q: term } })
-        return request(`${getType(options)}/search?${qsParams}`, normalizeGifs, 'GIF_SEARCH') as Promise<GifsResult>
+        const pingbackType = options.type === 'text' ? 'TEXT_SEARCH' : 'GIF_SEARCH'
+        return request(`${getType(options)}/search?${qsParams}`, normalizeGifs, pingbackType) as Promise<GifsResult>
     }
 
     /**
@@ -103,8 +104,9 @@ export class GiphyFetch {
      * @param {TrendingOptions} options
      * @returns {Promise<GifsResult>}
      */
-    trending(options?: TrendingOptions): Promise<GifsResult> {
-        return request(`${getType(options)}/trending?${this.getQS(options)}`, normalizeGifs, 'GIF_TRENDING') as Promise<
+    trending(options: TrendingOptions = {}): Promise<GifsResult> {
+        const pingbackType = options.type === 'text' ? 'TEXT_TRENDING' : 'GIF_TRENDING'
+        return request(`${getType(options)}/trending?${this.getQS(options)}`, normalizeGifs, pingbackType) as Promise<
             GifsResult
         >
     }

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -29,7 +29,8 @@ export interface TrendingOptions extends PaginationOptions, TypeOption {
     rating?: Rating
 }
 
-export interface RandomOptions extends PaginationOptions, TypeOption {
+export interface RandomOptions extends PaginationOptions {
+    type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
     tag?: string
     rating?: Rating
 }

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -1,7 +1,7 @@
 /**
  * If you want gifs or stickers
  */
-export type MediaType = 'stickers' | 'gifs'
+export type MediaType = 'stickers' | 'gifs' | 'text'
 /**
  * Filters results by specified rating.
  */


### PR DESCRIPTION
Add `text` to the `MediaType`. `trending` and `search` have the `MediaType` as an option. `random` doesn't support `text`, so override its `MediaType` to be `gifs | stickers`

Also updated pingback events when the `MediaType` is `text`