### PR TITLE
feat(fetch-api): better error messages available

### DIFF
--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -3,6 +3,7 @@ import GiphyFetchAPI from '../api'
 // eslint-disable-next-line
 import * as fetch from 'jest-fetch-mock'
 import { IGif, PingbackEventType } from '@giphy/js-types'
+import { DEFAULT_ERROR, ERROR_PREFIX } from '../request'
 
 const dummyGif = {
     id: 12345,
@@ -146,7 +147,7 @@ describe('response parsing', () => {
         } catch (error) {
             expect(error.status).toBe(400)
             expect(error.statusText).toBe('Bad Request')
-            expect(error.message).toBe('Error fetching')
+            expect(error.message).toBe(`${ERROR_PREFIX}${DEFAULT_ERROR}`)
         }
     })
     test('error', async () => {

--- a/packages/fetch-api/src/request.ts
+++ b/packages/fetch-api/src/request.ts
@@ -1,6 +1,7 @@
 import { Result, ErrorResult } from './result-types'
 import { PingbackEventType } from '@giphy/js-types'
-
+export const ERROR_PREFIX = `@giphy/js-fetch-api: `
+export const DEFAULT_ERROR = 'Error fetching'
 const serverUrl = 'https://api.giphy.com/v1/'
 const identity = (i: any) => i
 const requestMap: { [key: string]: Promise<Result> } = {}
@@ -17,7 +18,7 @@ function request(
                     const result = (await response.json()) as Result
                     resolve(normalizer(result, pingbackType))
                 } else {
-                    let message = 'Error fetching'
+                    let message = DEFAULT_ERROR
                     try {
                         // error results have a different format than regular results
                         const result = (await response.json()) as ErrorResult
@@ -26,7 +27,7 @@ function request(
                     reject({
                         status: response.status,
                         statusText: response.statusText,
-                        message: `@giphy/js-fetch-api: ${message}`,
+                        message: `${ERROR_PREFIX}${message}`,
                     })
                 }
             } catch (error) {

--- a/packages/fetch-api/src/request.ts
+++ b/packages/fetch-api/src/request.ts
@@ -1,4 +1,4 @@
-import { Result } from './result-types'
+import { Result, ErrorResult } from './result-types'
 import { PingbackEventType } from '@giphy/js-types'
 
 const serverUrl = 'https://api.giphy.com/v1/'
@@ -17,10 +17,16 @@ function request(
                     const result = (await response.json()) as Result
                     resolve(normalizer(result, pingbackType))
                 } else {
+                    let message = 'Error fetching'
+                    try {
+                        // error results have a different format than regular results
+                        const result = (await response.json()) as ErrorResult
+                        if (result.message) message = result.message
+                    } catch (_) {}
                     reject({
                         status: response.status,
                         statusText: response.statusText,
-                        message: 'Error fetching',
+                        message: `@giphy/js-fetch-api: ${message}`,
                     })
                 }
             } catch (error) {

--- a/packages/fetch-api/src/result-types.ts
+++ b/packages/fetch-api/src/result-types.ts
@@ -12,6 +12,10 @@ export interface Result {
         offset: number
     }
 }
+
+export interface ErrorResult {
+    message?: string
+}
 export interface GifResult extends Result {
     data: IGif
 }


### PR DESCRIPTION
No more CORS issues, we get a real error message now. The format is different than the success messages with json body consisting solely off a `message` field. I created a new type for this called `ErrorResult`
<img width="772" alt="Screen Shot 2019-08-22 at 4 26 37 PM" src="https://user-images.githubusercontent.com/448767/63547203-a5425780-c4f9-11e9-9db7-dd600192afcd.png">
