### PR TITLE
feat(react-components): move background to img

### DIFF
--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -182,7 +182,6 @@ const Gif = ({
         <a
             href={gif.url}
             style={{
-                backgroundColor: bgColor,
                 width,
                 height,
             }}
@@ -193,9 +192,14 @@ const Gif = ({
             onContextMenu={(e: SyntheticEvent<HTMLElement, Event>) => onGifRightClick(gif, e)}
             ref={container}
         >
-            {showGif ? (
-                <img src={fit} width={width} height={height} alt={getAltText(gif)} onLoad={onImageLoad} />
-            ) : null}
+            <img
+                src={showGif ? fit : placeholder}
+                style={{ backgroundColor: bgColor }}
+                width={width}
+                height={height}
+                alt={getAltText(gif)}
+                onLoad={showGif ? onImageLoad : () => {}}
+            />
             {showGif ? <AdPill bottleData={bottleData} /> : null}
             {Overlay && <Overlay gif={gif} isHovered={isHovered} />}
         </a>


### PR DESCRIPTION
we can style a gif with padding (e.g. in a grid to make room for giphy tv), and we'd want the background and the img to receive the padding