### PR TITLE
feat(fetch-api): search channels

### DIFF
--- a/packages/fetch-api/public/index.tsx
+++ b/packages/fetch-api/public/index.tsx
@@ -50,6 +50,14 @@ const search = async () => {
         console.error('search', error)
     }
 }
+const searchChannel = async () => {
+    try {
+        const result = await gf.search('dogs', { sort: 'recent', channel: 'reactions' })
+        console.log('search channel', result)
+    } catch (error) {
+        console.error('search', error)
+    }
+}
 const subcategories = async () => {
     try {
         const result = await gf.subcategories('tv')
@@ -105,6 +113,7 @@ const textTrending = async () => {
 }
 categories()
 search()
+searchChannel()
 gif()
 gifs()
 gifByCategory()

--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -29,7 +29,10 @@ const gifResponse = {
     pagination,
     meta,
 }
-
+const okResponseWithError = {
+    ...gifsResponse,
+    message: "response was okay, but here's a message",
+}
 const gifResponseWithUser = {
     ...gifResponse,
     data: {
@@ -139,6 +142,14 @@ describe('response parsing', () => {
         fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
         const { data } = await gf.trending({ type: 'text' })
         testDummyGif(data[0], 'TEXT_TRENDING')
+    })
+    test('response ok with message', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(okResponseWithError), { status: 403 })
+        try {
+            await gf.related('d')
+        } catch (error) {
+            expect(error.message).toBe(`${ERROR_PREFIX}${okResponseWithError.message}`)
+        }
     })
     test('error', async () => {
         fetchMock.mockResponses([JSON.stringify({}), { status: 400 }])

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -86,7 +86,8 @@ export class GiphyFetch {
      * @returns {Promise<GifsResult>}
      **/
     search(term: string, options: SearchOptions = {}): Promise<GifsResult> {
-        const qsParams = this.getQS({ ...options, ...{ q: term } })
+        const q = options.channel ? `@${options.channel} ${term}` : term
+        const qsParams = this.getQS({ ...options, q })
         const pingbackType = options.type === 'text' ? 'TEXT_SEARCH' : 'GIF_SEARCH'
         return request(`${getType(options)}/search?${qsParams}`, normalizeGifs, pingbackType) as Promise<GifsResult>
     }

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -39,4 +39,5 @@ export interface SearchOptions extends PaginationOptions, TypeOption {
     sort?: SortTypes
     rating?: Rating
     lang?: string
+    channel?: string
 }


### PR DESCRIPTION
This was already available but I added an explicit search option
Also got 100% coverage back on fetch-api