### PR TITLE
feat(grids): increase debounce

### DIFF
--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -41,6 +41,7 @@ const initialState = Object.freeze({
 class Grid extends Component<Props, State> {
     static className = 'giphy-grid'
     static readonly defaultProps = defaultProps
+    static fetchDebounce = 250
     readonly state = initialState
     bricks?: any
     el: HTMLElement | null = null
@@ -99,7 +100,7 @@ class Grid extends Component<Props, State> {
         this.setState({ isLoaderVisible: isVisible }, this.onFetch)
     }
 
-    onFetch = debounce(100, async () => {
+    onFetch = debounce(Grid.fetchDebounce, async () => {
         const { isFetching, isLoaderVisible, gifs: existingGifs } = this.state
         if (!isFetching && isLoaderVisible) {
             this.setState({ isFetching: true, isError: false })

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -43,6 +43,7 @@ const initialState = Object.freeze({
 class Grid extends PureComponent<Props, State> {
     static className = 'giphy-grid'
     static loaderClassName = 'loader'
+    static fetchDebounce = 250
     static readonly defaultProps = defaultProps
     readonly state = initialState
     bricks?: any
@@ -105,7 +106,7 @@ class Grid extends PureComponent<Props, State> {
         this.setState({ isLoaderVisible: isVisible }, this.onFetch)
     }
 
-    onFetch = debounce(100, async () => {
+    onFetch = debounce(Grid.fetchDebounce, async () => {
         const { isFetching, isLoaderVisible, gifs: existingGifs } = this.state
         if (!isFetching && isLoaderVisible) {
             this.setState({ isFetching: true, isError: false })


### PR DESCRIPTION
sometimes it takes more than
100 ms to render the gifs,
(like on page load)
this will cause two fetches

<img width="879" alt="Screen Shot 2020-03-06 at 2 39 44 PM" src="https://user-images.githubusercontent.com/448767/76128135-5604d580-5fb8-11ea-81f9-82393626c289.png">
