### PR TITLE
GIF - Proposal for optional noLink prop

### DIFF
--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -19,7 +19,7 @@ export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLOR
 
 const hoverTimeoutDelay = 200
 
-const WithLink = (props: any) => (props.href ? <a href={props.href} {...props} /> : <div {...props} />)
+const Container = (props: any) => (props.href ? <a href={props.href} {...props} /> : <div {...props} />)
 
 export type EventProps = {
     // fired on desktop when hovered for
@@ -46,13 +46,13 @@ export type GifOverlayProps = {
 
 type GifProps = {
     gif: IGif
-    as?: 'a' | 'div'
     width: number
     height?: number
     backgroundColor?: string
     className?: string
     user?: Partial<IUser>
     hideAttribution?: boolean
+    noLink?: boolean
 }
 
 export type Props = GifProps & EventProps
@@ -62,7 +62,6 @@ const placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAAL
 const noop = () => {}
 
 const Gif = ({
-    as = 'a',
     gif,
     gif: { bottle_data: bottleData = {} },
     width,
@@ -75,6 +74,7 @@ const Gif = ({
     user = {},
     backgroundColor,
     hideAttribution = false,
+    noLink = false,
 }: Props) => {
     // only fire seen once per gif id
     const [hasFiredSeen, setHasFiredSeen] = useState(false)
@@ -227,8 +227,8 @@ const Gif = ({
             : defaultBgColor.current)
 
     return (
-        <WithLink
-            href={as === 'a' ? gif.url : ''}
+        <Container
+            href={noLink ? '' : gif.url}
             style={{
                 width,
                 height,
@@ -256,7 +256,7 @@ const Gif = ({
                     </div>
                 ) : null}
             </div>
-        </WithLink>
+        </Container>
     )
 }
 

--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -19,6 +19,8 @@ export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLOR
 
 const hoverTimeoutDelay = 200
 
+const WithLink = (props: any) => (props.href ? <a href={props.href} {...props} /> : <div {...props} />)
+
 export type EventProps = {
     // fired on desktop when hovered for
     onGifHover?: (gif: IGif, e: Event) => void
@@ -44,6 +46,7 @@ export type GifOverlayProps = {
 
 type GifProps = {
     gif: IGif
+    as?: 'a' | 'div'
     width: number
     height?: number
     backgroundColor?: string
@@ -59,6 +62,7 @@ const placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAAL
 const noop = () => {}
 
 const Gif = ({
+    as = 'a',
     gif,
     gif: { bottle_data: bottleData = {} },
     width,
@@ -83,7 +87,7 @@ const Gif = ({
     // the background color shouldn't change unless it comes from a prop or we have a sticker
     const defaultBgColor = useRef(getColor())
     // the a tag the media is rendered into
-    const container = useRef<HTMLAnchorElement | null>(null)
+    const container = useRef<HTMLDivElement | null>(null)
     // intersection observer with no threshold
     const showGifObserver = useMutableRef<IntersectionObserver>()
     // intersection observer with a threshold of 1 (full element is on screen)
@@ -223,8 +227,8 @@ const Gif = ({
             : defaultBgColor.current)
 
     return (
-        <a
-            href={gif.url}
+        <WithLink
+            href={as === 'a' ? gif.url : ''}
             style={{
                 width,
                 height,
@@ -234,9 +238,8 @@ const Gif = ({
             onMouseLeave={onMouseLeave}
             onClick={onClick}
             onContextMenu={(e: Event) => onGifRightClick(gif, e)}
-            ref={container}
         >
-            <div style={{ width, height, position: 'relative' }}>
+            <div style={{ width, height, position: 'relative' }} ref={container}>
                 <img
                     className={Gif.imgClassName}
                     src={showGif ? fit : placeholder}
@@ -253,7 +256,7 @@ const Gif = ({
                     </div>
                 ) : null}
             </div>
-        </a>
+        </WithLink>
     )
 }
 

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -3,7 +3,7 @@ import { IGif, IUser } from '@giphy/js-types'
 import { checkIfWebP, getAltText, getBestRenditionUrl, getGifHeight, Logger, constructMoatData } from '@giphy/js-util'
 import moat from '@giphy/moat-loader'
 import { css, cx } from 'emotion'
-import React, { ReactType, SyntheticEvent, useEffect, useRef, useState } from 'react'
+import React, { ReactType, SyntheticEvent, useEffect, useRef, useState, HTMLProps } from 'react'
 import * as pingback from '../util/pingback'
 import AdPill from './ad-pill'
 import AttributionOverlay from './attribution/overlay'
@@ -18,7 +18,9 @@ export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLOR
 
 const hoverTimeoutDelay = 200
 
-const WithLink = (props: any) => (props.href ? <a href={props.href} {...props} /> : <div {...props} />)
+type ContainerProps = HTMLProps<HTMLElement> & { href: string }
+const Container = (props: ContainerProps) =>
+    props.href ? <a {...(props as HTMLProps<HTMLAnchorElement>)} /> : <div {...(props as HTMLProps<HTMLDivElement>)} />
 
 export type EventProps = {
     // fired every time the gif is show
@@ -38,7 +40,6 @@ export type GifOverlayProps = {
 
 type GifProps = {
     gif: IGif
-    as?: 'a' | 'div'
     width: number
     height?: number
     backgroundColor?: string
@@ -46,6 +47,7 @@ type GifProps = {
     user?: Partial<IUser>
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
+    noLink?: boolean
 }
 
 type Props = GifProps & EventProps
@@ -55,7 +57,6 @@ const placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAAL
 const noop = () => {}
 
 const Gif = ({
-    as = 'a',
     gif,
     gif: { bottle_data: bottleData = {} },
     width,
@@ -69,6 +70,7 @@ const Gif = ({
     backgroundColor,
     overlay,
     hideAttribution = false,
+    noLink = false,
 }: Props) => {
     // only fire seen once per gif id
     const [hasFiredSeen, setHasFiredSeen] = useState(false)
@@ -228,8 +230,8 @@ const Gif = ({
             : defaultBgColor.current)
 
     return (
-        <WithLink
-            href={as === 'a' ? gif.url : null}
+        <Container
+            href={noLink ? '' : gif.url}
             style={{
                 width,
                 height,
@@ -257,7 +259,7 @@ const Gif = ({
                     </>
                 ) : null}
             </div>
-        </WithLink>
+        </Container>
     )
 }
 

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -18,6 +18,8 @@ export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLOR
 
 const hoverTimeoutDelay = 200
 
+const WithLink = (props: any) => (props.href ? <a href={props.href} {...props} /> : <div {...props} />)
+
 export type EventProps = {
     // fired every time the gif is show
     onGifVisible?: (gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void
@@ -36,6 +38,7 @@ export type GifOverlayProps = {
 
 type GifProps = {
     gif: IGif
+    as?: 'a' | 'div'
     width: number
     height?: number
     backgroundColor?: string
@@ -52,6 +55,7 @@ const placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAAL
 const noop = () => {}
 
 const Gif = ({
+    as = 'a',
     gif,
     gif: { bottle_data: bottleData = {} },
     width,
@@ -77,7 +81,7 @@ const Gif = ({
     // the background color shouldn't change unless it comes from a prop or we have a sticker
     const defaultBgColor = useRef(getColor())
     // the a tag the media is rendered into
-    const container = useRef<HTMLAnchorElement | null>(null)
+    const container = useRef<HTMLDivElement | null>(null)
     // intersection observer with no threshold
     const showGifObserver = useRef<IntersectionObserver>()
     // intersection observer with a threshold of 1 (full element is on screen)
@@ -224,8 +228,8 @@ const Gif = ({
             : defaultBgColor.current)
 
     return (
-        <a
-            href={gif.url}
+        <WithLink
+            href={as === 'a' ? gif.url : null}
             style={{
                 width,
                 height,
@@ -235,9 +239,8 @@ const Gif = ({
             onMouseLeave={onMouseLeave}
             onClick={onClick}
             onContextMenu={(e: SyntheticEvent<HTMLElement, Event>) => onGifRightClick(gif, e)}
-            ref={container}
         >
-            <div style={{ width, height, position: 'relative' }}>
+            <div style={{ width, height, position: 'relative' }} ref={container}>
                 <img
                     className={Gif.imgClassName}
                     src={showGif ? fit : placeholder}
@@ -254,7 +257,7 @@ const Gif = ({
                     </>
                 ) : null}
             </div>
-        </a>
+        </WithLink>
     )
 }
 

--- a/packages/react-components/stories/gif.stories.tsx
+++ b/packages/react-components/stories/gif.stories.tsx
@@ -1,7 +1,7 @@
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { IGif } from '@giphy/js-types'
 import { action } from '@storybook/addon-actions'
-import { withKnobs, text, number } from '@storybook/addon-knobs'
+import { withKnobs, text, number, boolean } from '@storybook/addon-knobs'
 import { jsxDecorator } from 'storybook-addon-jsx'
 
 import React, { useEffect, useState } from 'react'
@@ -13,7 +13,7 @@ const eventAction = (event: string) => (gif: IGif) => {
     action(`Gif ${event} for ${gif.id}`)()
 }
 
-const GifDemo = ({ id, width }: { id: string; width: number }) => {
+const GifDemo = ({ id, width, noLink }: { id: string; width: number; noLink?: boolean }) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = async () => {
@@ -27,8 +27,10 @@ const GifDemo = ({ id, width }: { id: string; width: number }) => {
 
     return gif ? (
         <GifComponent
+            key={`gif-${noLink}`}
             gif={gif}
             width={width}
+            noLink={noLink}
             onGifClick={eventAction('click')}
             onGifSeen={eventAction('seen')}
             onGifVisible={eventAction('visible')}
@@ -41,5 +43,9 @@ export default {
     decorators: [withKnobs, jsxDecorator],
 }
 
-export const Gif = () => <GifDemo id={text('id', 'ZEU9ryYGZzttn0Cva7')} width={number('width', 300)} />
-export const Sticker = () => <GifDemo id={text('id', 'l1J9FvenuBnI4GTeg')} width={number('width', 300)} />
+export const Gif = () => (
+    <GifDemo id={text('id', 'ZEU9ryYGZzttn0Cva7')} width={number('width', 300)} noLink={boolean('noLink', false)} />
+)
+export const Sticker = () => (
+    <GifDemo id={text('id', 'l1J9FvenuBnI4GTeg')} width={number('width', 300)} noLink={boolean('noLink', false)} />
+)


### PR DESCRIPTION
Adding an `as` prop which can be eitehr `a` or `div`. This allows the use of the GIF component without the anchor attached to it. This is useful for times you want the gif lazy loading, analytics, etc. but you don't want it to link to the gif detail page.