### PR TITLE
Fixing noLink GIFs

### DIFF
--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -228,7 +228,7 @@ const Gif = ({
 
     return (
         <Container
-            href={noLink ? '' : gif.url}
+            href={noLink ? undefined : gif.url}
             style={{
                 width,
                 height,

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -18,7 +18,7 @@ export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLOR
 
 const hoverTimeoutDelay = 200
 
-type ContainerProps = HTMLProps<HTMLElement> & { href: string }
+type ContainerProps = HTMLProps<HTMLElement> & { href?: string }
 const Container = (props: ContainerProps) =>
     props.href ? <a {...(props as HTMLProps<HTMLAnchorElement>)} /> : <div {...(props as HTMLProps<HTMLDivElement>)} />
 
@@ -231,7 +231,7 @@ const Gif = ({
 
     return (
         <Container
-            href={noLink ? '' : gif.url}
+            href={noLink ? undefined : gif.url}
             style={{
                 width,
                 height,


### PR DESCRIPTION
Making `href` prop passing to `Container` optional and `undefined` when `noLink` is set to `true`