### PR TITLE
fix(node-support): check browser-only apis

### DIFF
--- a/packages/analytics/src/__tests__/pingback-requests.test.ts
+++ b/packages/analytics/src/__tests__/pingback-requests.test.ts
@@ -2,7 +2,7 @@ import { IGif, IUser } from '@giphy/js-types'
 import pingback from '../pingback'
 import { SESSION_STORAGE_KEY, addLastSearchResponseId } from '../session'
 
-const gl = (window || global || {}) as any
+const gl = ((typeof window !== 'undefined' ? window : global) || {}) as any
 
 describe('pingback', () => {
     afterEach(() => {

--- a/packages/analytics/src/session.ts
+++ b/packages/analytics/src/session.ts
@@ -37,7 +37,7 @@ export function addLastSearchResponseId(responseId: string) {
         if (existing) {
             var searchResponseIds = JSON.parse(existing)
             if (searchResponseIds[searchResponseIds.length - 1] !== responseId) {
-                window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify([...searchResponseIds, responseId]))
+                sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify([...searchResponseIds, responseId]))
             }
         } else {
             sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify([responseId]))
@@ -45,7 +45,7 @@ export function addLastSearchResponseId(responseId: string) {
     } catch (_) {}
 }
 
-const gl = (window || global || {}) as any
+const gl = ((typeof window !== 'undefined' ? window : global) || {}) as any
 gl.giphyRandomId = ''
 const getRandomId = () => {
     // it exists in memory

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -34,7 +34,8 @@ export class GiphyFetch {
      * @hidden
      */
     private getQS = (options: any = {}) => {
-        const { giphy_pbid: pingback_id } = cookie.parse(document.cookie)
+        const { giphy_pbid: pingback_id } =
+            typeof document !== 'undefined' ? cookie.parse(document.cookie) : ({} as any)
         return qs.stringify({ ...options, api_key: this.apiKey, pingback_id })
     }
 

--- a/packages/util/src/log.ts
+++ b/packages/util/src/log.ts
@@ -7,7 +7,7 @@ export enum LogLevel {
 }
 /* istanbul ignore next */
 export const Logger = {
-    ENABLED: window && location && location.search.indexOf('giphy-debug') !== -1,
+    ENABLED: typeof window !== 'undefined' && location && location.search.indexOf('giphy-debug') !== -1,
     LEVEL: 0,
     PREFIX: 'GiphyJS',
     debug: function(...msg: any) {

--- a/packages/util/src/sdk-headers.ts
+++ b/packages/util/src/sdk-headers.ts
@@ -1,5 +1,5 @@
 type GiphySDKRequestHeader = 'X-GIPHY-SDK-NAME' | 'X-GIPHY-SDK-VERSION' | 'X-GIPHY-SDK-PLATFORM'
-const gl = (window || global || {}) as any
+const gl = ((typeof window !== 'undefined' ? window : global) || {}) as any
 // define _GIPHY_SDK_HEADERS_ if they don't exist
 gl._GIPHY_SDK_HEADERS_ =
     gl._GIPHY_SDK_HEADERS_ ||

--- a/packages/util/src/webp-check.ts
+++ b/packages/util/src/webp-check.ts
@@ -1,6 +1,9 @@
 export let SUPPORTS_WEBP: null | boolean = null
 /* istanbul ignore next */
 export const checkIfWebP = new Promise(resolve => {
+    if (typeof Image === 'undefined') {
+        resolve(false)
+    }
     const webp = new Image()
     webp.onload = () => {
         SUPPORTS_WEBP = true

--- a/packages/util/yarn.lock
+++ b/packages/util/yarn.lock
@@ -28,8 +28,3 @@ typescript@^3.8.2:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-unfetch@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
-  integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==


### PR DESCRIPTION
I'm now able to run this is in a node environment. Fixes #58 

This will work when I release:
https://codesandbox.io/s/fetch-api-in-express-kwfq8