### PR TITLE
fix(components): remove components properly

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -67,9 +67,9 @@ const makeGrid = (targetEl: HTMLElement) => {
     }
     const resizeRender = throttle(500, render)
     window.addEventListener('resize', resizeRender, false)
-    const el = render()
+    const remove = render()
     return () => {
-        el.parentNode.removeChild(el)
+        remove()
         window.removeEventListener('resize', resizeRender, false)
     }
 }

--- a/packages/components/public/grid-demo.tsx
+++ b/packages/components/public/grid-demo.tsx
@@ -48,7 +48,7 @@ export class VanillaJSGrid {
 
     render = () => {
         const width = getWidth()
-        this.el = renderGrid(
+        this.remove = renderGrid(
             {
                 width,
                 fetchGifs,
@@ -56,11 +56,11 @@ export class VanillaJSGrid {
                 gutter: 6,
             },
             this.mountNode
-        ) as HTMLElement
+        )
     }
 
     remove() {
-        this.el.parentNode.removeChild(this.el)
+        this.remove()
     }
 }
 
@@ -76,13 +76,13 @@ export const vanillaJSGrid = (mountNode: HTMLElement) => {
                 onGifsFetchError: error => console.error(`Gif Grid fetch error`, error),
             },
             mountNode
-        ) as HTMLElement
+        )
     }
     const resizeRender = throttle(500, render)
     window.addEventListener('resize', resizeRender, false)
-    const el = render()
+    const remove = render()
     return () => {
-        el.parentNode.removeChild(el)
+        remove()
         window.removeEventListener('resize', resizeRender, false)
     }
 }

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -11,7 +11,7 @@ import FetchError from './fetch-error'
 type Props = {
     className?: string
     width: number
-    user: Partial<IUser>
+    user?: Partial<IUser>
     columns: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -15,15 +15,16 @@ const { version } = require('../package.json')
 appendGiphySDKRequestHeader(`X-GIPHY-SDK-NAME`, 'JavascriptSDK')
 appendGiphySDKRequestHeader(`X-GIPHY-SDK-VERSION`, version)
 
+type RemoveCallback = () => void
 /**
  * render a grid
  *
  * @param gridProps grid props
  * @param target the node to render into it
  */
-export const renderGrid = (gridProps: Grid['props'], target: HTMLElement): Element => {
+export const renderGrid = (gridProps: Grid['props'], target: HTMLElement): RemoveCallback => {
     render(<Grid {...gridProps} />, target)
-    return target.querySelector(`.${gridProps.className || Grid.className}`)!
+    return () => render(null, target)
 }
 
 /**
@@ -32,9 +33,9 @@ export const renderGrid = (gridProps: Grid['props'], target: HTMLElement): Eleme
  * @param carouselProps Carousel props
  * @param target the node to render into it
  */
-export const renderCarousel = (carouselProps: Carousel['props'], target: HTMLElement): Element => {
+export const renderCarousel = (carouselProps: Carousel['props'], target: HTMLElement): RemoveCallback => {
     render(<Carousel {...carouselProps} />, target)
-    return target.querySelector(`.${carouselProps.className || Carousel.className}`)!
+    return () => render(null, target)
 }
 
 /**
@@ -43,7 +44,7 @@ export const renderCarousel = (carouselProps: Carousel['props'], target: HTMLEle
  * @param gif Gif props
  * @param target the node to render into it
  */
-export const renderGif = (gifProps: GifProps, target: HTMLElement): Element => {
+export const renderGif = (gifProps: GifProps, target: HTMLElement): RemoveCallback => {
     render(<Gif {...gifProps} />, target)
-    return target.querySelector(`.${gifProps.className || Gif.className}`)!
+    return () => render(null, target)
 }


### PR DESCRIPTION
My plan for removing components in the Vanilla JS SDK was a bit off, returning the element and then letting the user remove the element still left the element in the `Preact` virtual dom, and a subsequent render (perhaps with a new `fetchGifs`) would re-render the existing component. 

I'm updating `remove` to `render(null)`, and then a subsequent render will create a new component instead of re-rendering the existing component. 

Fixes #65 

This is an API change so I'l l have to do a major bump. 
Also, I'm wondering if returning the element was  of any use to anybody. 

Technically it can still be accessed via: `querySelector`:

```typescript 
// the user specified class name or the default 
// class name of the component, below is `Gif.className`
target.querySelector(`.${aUsersClassName || Gif.className}`)