### PR TITLE
fix(pingback): custom attribute 

### DIFF
--- a/packages/analytics/src/util.ts
+++ b/packages/analytics/src/util.ts
@@ -1,4 +1,4 @@
-import { PingbackRequestAction, PingbackActionType, PingbackAttribute } from './types'
+import { PingbackActionType, PingbackAttribute, PingbackRequestAction } from './types'
 
 export function getAction(
     action_type: PingbackActionType,
@@ -7,7 +7,11 @@ export function getAction(
     position?: ClientRect,
     attributes: PingbackAttribute[] = []
 ): PingbackRequestAction {
-    if (position) {
+    if (
+        position &&
+        // apppend position only if it's not passed as a custom attribute
+        !attributes.some(attributes => attributes.key === 'position')
+    ) {
         attributes.push({
             key: `position`,
             value: JSON.stringify(position),

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -142,7 +142,7 @@ const Gif = ({
 
     const onClick = (e: SyntheticEvent<HTMLElement, Event>) => {
         // fire pingback
-        pingback.onGifClick(gif, user, e.target as HTMLElement)
+        pingback.onGifClick(gif, user, e.target as HTMLElement, attributes)
         onGifClick(gif, e)
     }
 
@@ -156,7 +156,7 @@ const Gif = ({
             injectTrackingPixel(gif.bottle_data.tags)
         }
         // fire pingback
-        pingback.onGifSeen(gif, user, entry.boundingClientRect)
+        pingback.onGifSeen(gif, user, entry.boundingClientRect, attributes)
         // fire custom onGifSeen
         onGifSeen?.(gif, entry.boundingClientRect)
         // disconnect


### PR DESCRIPTION
- don't append client rect if `key: position`  is passed in
- add a test
- add attributes to all pingback events 