### PR TITLE
fix(intersection-observer): tweak threshold to be slightly forgiving

### DIFF
--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -20,6 +20,9 @@ import AttributionOverlay from './attribution/overlay'
 const moatLoader = moat.loadMoatTag('giphydisplay879451385633', 'https://giphyscripts.s3.amazonaws.com/moat/moatad.js')
 const gifCss = css`
     display: block;
+    img {
+        display: block;
+    }
 `
 
 export const GRID_COLORS = [giphyBlue, giphyGreen, giphyPurple, giphyRed, giphyYellow]
@@ -168,7 +171,7 @@ const Gif = ({
                         sendOnSeen.current(entry)
                     }
                 },
-                { threshold: [1] }
+                { threshold: [0.99] }
             )
         }
         if (!hasFiredSeen && container.current && fullGifObserver.current) {

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -32,6 +32,9 @@ export const PingbackContext = createContext({} as PingbackContextProps)
 const moatLoader = moat.loadMoatTag('giphydisplay879451385633')
 const gifCss = css`
     display: block;
+    img {
+        display: block;
+    }
 `
 
 export const GRID_COLORS = [giphyBlue, giphyGreen, giphyPurple, giphyRed, giphyYellow]
@@ -186,7 +189,7 @@ const Gif = ({
                         sendOnSeen.current(entry)
                     }
                 },
-                { threshold: [1] }
+                { threshold: [0.99] }
             )
         }
         if (!hasFiredSeen && container.current && fullGifObserver.current) {


### PR DESCRIPTION
Noticed a quirk on Android were a `Gif` component wasn't reporting a fully visible threshold of `1` when the container it was in had an `overflow: hidden | scroll`, even though the container's size was the same as the element it was wrapping, the `threshold` was reporting at about `.996`. 

To give a little leniency to developers, and to avoid not reporting `SEEN` events because of a browser quirk, I changed the fully visible threshold to `.99` 