### PR TITLE
feature: add no result props when response is empty

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -31,7 +31,7 @@ _renderGrid options_
 | fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | columns                                 | `number`                                 | 3          | The number of columns in the grid                                        |
 | gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
-| noResultMessage                         | `string || element`                      | No results | Customise the "No results" message                                       |
+| noResultsMessage                        | `string || element`                      | No results | Customise the "No results" message                                       |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a                            |
 | [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 
@@ -91,7 +91,7 @@ _renderCarousel options_
 | gifHeight                               | `number`                                 | undefined  | The height of the gifs and the carousel                                  |
 | fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
-| noResultMessage                         | `string || element`                      | No results | Customise the "No results" message                                       |
+| noResultsMessage                        | `string || element`                      | No results | Customise the "No results" message                                       |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a                            |
 | [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -25,14 +25,15 @@ renderGrid({ width: 800, fetchGifs }, targetEl)
 
 _renderGrid options_
 
-| _prop_                                  | _type_                                   | _default_ | _description_                                                            |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| width                                   | `number`                                 | undefined | The width of the grid                                                    |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| columns                                 | `number`                                 | 3         | The number of columns in the grid                                        |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                            |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| _prop_                                  | _type_                                   | _default_  | _description_                                                            |
+| --------------------------------------- | ---------------------------------------- | ---------- | ------------------------------------------------------------------------ |
+| width                                   | `number`                                 | undefined  | The width of the grid                                                    |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| columns                                 | `number`                                 | 3          | The number of columns in the grid                                        |
+| gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
+| noResultMessage                         | `string || element`                      | No results | Customise the "No results" message                                       |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a                            |
+| [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 
 ### Thorough Example
 
@@ -85,13 +86,14 @@ grid.remove()
 
 _renderCarousel options_
 
-| property                                | type                                     | default   | description                                                              |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                            |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| property                                | type                                     | default    | description                                                              |
+| --------------------------------------- | ---------------------------------------- | ---------- | ------------------------------------------------------------------------ |
+| gifHeight                               | `number`                                 | undefined  | The height of the gifs and the carousel                                  |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
+| noResultMessage                         | `string || element`                      | No results | Customise the "No results" message                                       |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a                            |
+| [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 
 ```typescript
 import { renderCarousel } from '@giphy/js-components'

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -40,9 +40,10 @@ type Props = {
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
+    noResultMessage?: string | HTMLElement
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {} })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
 
 type State = {
     isFetching: boolean
@@ -108,6 +109,7 @@ class Carousel extends Component<Props, State> {
             onGifHover,
             onGifSeen,
             user,
+            noResultMessage,
         }: Props,
         { gifs }: State
     ) {
@@ -139,6 +141,7 @@ class Carousel extends Component<Props, State> {
                         />
                     )
                 })}
+                {!showLoader && gifs.length === 0 && noResultMessage}
                 {showLoader && (
                     <Observer className={loaderContainerCss} onVisibleChange={this.onLoaderVisible}>
                         <div className={cx(loaderCss, gifHeightCss)} />

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -3,7 +3,7 @@ import { debounce } from 'throttle-debounce'
 import { IGif, IUser } from '@giphy/js-types'
 import { getGifWidth } from '@giphy/js-util'
 import { css, cx } from 'emotion'
-import { Component, h } from 'preact'
+import { Component, h, JSX } from 'preact'
 import Observer from '../util/observer'
 import Gif, { EventProps } from './gif'
 
@@ -40,10 +40,10 @@ type Props = {
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
-    noResultMessage?: string | HTMLElement
+    noResultsMessage?: string | JSX.Element
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultsMessage: 'No results' })
 
 type State = {
     isFetching: boolean
@@ -109,7 +109,7 @@ class Carousel extends Component<Props, State> {
             onGifHover,
             onGifSeen,
             user,
-            noResultMessage,
+            noResultsMessage,
         }: Props,
         { gifs }: State
     ) {
@@ -141,7 +141,7 @@ class Carousel extends Component<Props, State> {
                         />
                     )
                 })}
-                {!showLoader && gifs.length === 0 && noResultMessage}
+                {!showLoader && gifs.length === 0 && noResultsMessage}
                 {showLoader && (
                     <Observer className={loaderContainerCss} onVisibleChange={this.onLoaderVisible}>
                         <div className={cx(loaderCss, gifHeightCss)} />

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact'
+import { h, Component, JSX } from 'preact'
 import { debounce } from 'throttle-debounce'
 import Gif, { EventProps } from './gif'
 import Bricks from 'bricks.js'
@@ -17,9 +17,9 @@ type Props = {
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void
-    noResultMessage?: string | HTMLElement
+    noResultsMessage?: string | JSX.Element
 } & EventProps
-const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultsMessage: 'No results' })
 
 type State = {
     gifWidth: number
@@ -136,7 +136,7 @@ class Grid extends Component<Props, State> {
             onGifHover,
             onGifSeen,
             user,
-            noResultMessage,
+            noResultsMessage,
         }: Props,
         { gifWidth, gifs, isError, isDoneFetching }: State
     ) {
@@ -157,7 +157,7 @@ class Grid extends Component<Props, State> {
                             user={user}
                         />
                     ))}
-                    {!showLoader && gifs.length === 0 && noResultMessage}
+                    {!showLoader && gifs.length === 0 && noResultsMessage}
                 </div>
                 {isError ? (
                     <FetchError onClick={this.onFetch} />

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -17,8 +17,9 @@ type Props = {
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void
+    noResultMessage?: string | HTMLElement
 } & EventProps
-const defaultProps = Object.freeze({ gutter: 6, user: {} })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
 
 type State = {
     gifWidth: number
@@ -135,6 +136,7 @@ class Grid extends Component<Props, State> {
             onGifHover,
             onGifSeen,
             user,
+            noResultMessage,
         }: Props,
         { gifWidth, gifs, isError, isDoneFetching }: State
     ) {
@@ -155,6 +157,7 @@ class Grid extends Component<Props, State> {
                             user={user}
                         />
                     ))}
+                    {!showLoader && gifs.length === 0 && noResultMessage}
                 </div>
                 {isError ? (
                     <FetchError onClick={this.onFetch} />

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -44,24 +44,26 @@ ReactDOM.render(<Grid width={800} columns={3} gutter={6} fetchGifs={fetchGifs} /
 
 <!-- The grid uses [bricks.js]() to render a grid with fixed width items. -->
 
-| _prop_                                  | _type_                                   | _default_ | _description_                                                            |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| width                                   | `number`                                 | undefined | The width of the grid                                                    |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| columns                                 | `number`                                 | 3         | The number of columns in the grid                                        |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                        |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| _prop_                                  | _type_                                   | _default_  | _description_                                                            |
+| --------------------------------------- | ---------------------------------------- | ---------- | ------------------------------------------------------------------------ |
+| width                                   | `number`                                 | undefined  | The width of the grid                                                    |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| columns                                 | `number`                                 | 3          | The number of columns in the grid                                        |
+| gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
+| noResultMessage                         | `string || component`                    | No results | Customise the "No results" message                                       |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a GIF                        |
+| [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 
 ## Carousel
 
-| _prop_                                  | _type_                                   | _default_ | _description_                                                            |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                        |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| _prop_                                  | _type_                                   | _default_  | _description_                                                            |
+| --------------------------------------- | ---------------------------------------- | ---------- | ------------------------------------------------------------------------ |
+| gifHeight                               | `number`                                 | undefined  | The height of the gifs and the carousel                                  |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
+| gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
+| noResultMessage                         | `string || component`                    | No results | Customise the "No results" message                                       |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a GIF                        |
+| [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 
 See [codesandbox](https://codesandbox.io/s/giphyreact-components-hbmcf?from-embed) for runnable code
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -50,7 +50,7 @@ ReactDOM.render(<Grid width={800} columns={3} gutter={6} fetchGifs={fetchGifs} /
 | fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | columns                                 | `number`                                 | 3          | The number of columns in the grid                                        |
 | gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
-| noResultMessage                         | `string || component`                    | No results | Customise the "No results" message                                       |
+| noResultsMessage                        | `string || component`                    | No results | Customise the "No results" message                                       |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a GIF                        |
 | [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 
@@ -61,7 +61,7 @@ ReactDOM.render(<Grid width={800} columns={3} gutter={6} fetchGifs={fetchGifs} /
 | gifHeight                               | `number`                                 | undefined  | The height of the gifs and the carousel                                  |
 | fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined  | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
 | gutter                                  | `number`                                 | 6          | The space between columns and rows                                       |
-| noResultMessage                         | `string || component`                    | No results | Customise the "No results" message                                       |
+| noResultsMessage                        | `string || component`                    | No results | Customise the "No results" message                                       |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false      | Hide the user attribution that appears over a GIF                        |
 | [Gif Events](#gif-events)               | \*                                       | \*         | see below                                                                |
 

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -53,10 +53,10 @@ type Props = {
     onGifsFetched?: (gifs: IGif[]) => void
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
-    noResultMessage?: string | JSX.Element
+    noResultsMessage?: string | JSX.Element
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultsMessage: 'No results' })
 type State = {
     isFetching: boolean
     gifs: IGif[]
@@ -126,7 +126,7 @@ class Carousel extends PureComponent<Props, State> {
             user,
             overlay,
             hideAttribution,
-            noResultMessage,
+            noResultsMessage,
         } = this.props
         const { gifs, isDoneFetching } = this.state
         const marginCss = css`
@@ -159,7 +159,7 @@ class Carousel extends PureComponent<Props, State> {
                         />
                     )
                 })}
-                {!showLoader && gifs.length === 0 && noResultMessage}
+                {!showLoader && gifs.length === 0 && noResultsMessage}
                 {showLoader && (
                     <Observer className={loaderContainerCss} onVisibleChange={this.onLoaderVisible}>
                         <div className={cx(loaderCss, gifHeightCss, isFirstLoad ? loaderHiddenCss : '')} />

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -53,9 +53,10 @@ type Props = {
     onGifsFetched?: (gifs: IGif[]) => void
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
+    noResultMessage?: string | JSX.Element
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {} })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
 type State = {
     isFetching: boolean
     gifs: IGif[]
@@ -125,6 +126,7 @@ class Carousel extends PureComponent<Props, State> {
             user,
             overlay,
             hideAttribution,
+            noResultMessage,
         } = this.props
         const { gifs, isDoneFetching } = this.state
         const marginCss = css`
@@ -157,6 +159,7 @@ class Carousel extends PureComponent<Props, State> {
                         />
                     )
                 })}
+                {!showLoader && gifs.length === 0 && noResultMessage}
                 {showLoader && (
                     <Observer className={loaderContainerCss} onVisibleChange={this.onLoaderVisible}>
                         <div className={cx(loaderCss, gifHeightCss, isFirstLoad ? loaderHiddenCss : '')} />

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -24,9 +24,10 @@ type Props = {
     onGifsFetchError?: (e: Error) => void
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
+    noResultMessage?: string | JSX.Element
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {} })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
 
 type State = {
     gifWidth: number
@@ -157,6 +158,7 @@ class Grid extends PureComponent<Props, State> {
             user,
             overlay,
             hideAttribution,
+            noResultMessage,
         } = this.props
         const { gifWidth, gifs, isError, isDoneFetching } = this.state
         const showLoader = fetchGifs && !isDoneFetching
@@ -178,6 +180,7 @@ class Grid extends PureComponent<Props, State> {
                             hideAttribution={hideAttribution}
                         />
                     ))}
+                    {!showLoader && gifs.length === 0 && noResultMessage}
                 </div>
                 {isError ? (
                     <FetchError onClick={this.onFetch} />

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -24,10 +24,10 @@ type Props = {
     onGifsFetchError?: (e: Error) => void
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
-    noResultMessage?: string | JSX.Element
+    noResultsMessage?: string | JSX.Element
 } & EventProps
 
-const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultMessage: 'No results' })
+const defaultProps = Object.freeze({ gutter: 6, user: {}, noResultsMessage: 'No results' })
 
 type State = {
     gifWidth: number
@@ -158,7 +158,7 @@ class Grid extends PureComponent<Props, State> {
             user,
             overlay,
             hideAttribution,
-            noResultMessage,
+            noResultsMessage,
         } = this.props
         const { gifWidth, gifs, isError, isDoneFetching } = this.state
         const showLoader = fetchGifs && !isDoneFetching
@@ -180,7 +180,7 @@ class Grid extends PureComponent<Props, State> {
                             hideAttribution={hideAttribution}
                         />
                     ))}
-                    {!showLoader && gifs.length === 0 && noResultMessage}
+                    {!showLoader && gifs.length === 0 && noResultsMessage}
                 </div>
                 {isError ? (
                     <FetchError onClick={this.onFetch} />


### PR DESCRIPTION
This adds the possibility of adding a customised `No results` text when the response returns empty.