### PR TITLE
fix(components): hide attribution missing on grid and carousel

### DIFF
--- a/packages/components/public/grid-demo.tsx
+++ b/packages/components/public/grid-demo.tsx
@@ -1,11 +1,14 @@
 import { GiphyFetch } from '@giphy/js-fetch-api'
-import { h, Component, render as preactRender } from 'preact' // eslint-disable-line no-unused-vars
+import { Component, h, render as preactRender } from 'preact' // eslint-disable-line no-unused-vars
 import { throttle } from 'throttle-debounce'
 import { Grid, renderGrid } from '../src'
 
 const getWidth = () => innerWidth
 const fetchGifs = (offset: number) => gf.trending({ offset, limit: 10 })
 const gf = new GiphyFetch('sXpGFDGZs0Dv1mmNFvYaGUvYwKX0PWIh')
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+h
 
 export namespace PreactGrid {
     type State = {

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -41,6 +41,7 @@ type Props = {
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
     noResultsMessage?: string | JSX.Element
+    hideAttribution?: boolean
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
@@ -110,6 +111,7 @@ class Carousel extends Component<Props, State> {
             onGifSeen,
             user,
             noResultsMessage,
+            hideAttribution,
         }: Props,
         { gifs }: State
     ) {
@@ -138,6 +140,7 @@ class Carousel extends Component<Props, State> {
                             onGifVisible={onGifVisible}
                             onGifRightClick={onGifRightClick}
                             user={user}
+                            hideAttribution={hideAttribution}
                         />
                     )
                 })}

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -23,6 +23,7 @@ type Props = {
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void
     noResultsMessage?: string | JSX.Element
+    hideAttribution?: boolean
 } & EventProps
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
 
@@ -143,6 +144,7 @@ class Grid extends Component<Props, State> {
             onGifSeen,
             user,
             noResultsMessage,
+            hideAttribution,
         }: Props,
         { gifWidth, gifs, isError, isDoneFetching }: State
     ) {
@@ -162,6 +164,7 @@ class Grid extends Component<Props, State> {
                             onGifVisible={onGifVisible}
                             onGifRightClick={onGifRightClick}
                             user={user}
+                            hideAttribution={hideAttribution}
                         />
                     ))}
                     {!showLoader && gifs.length === 0 && noResultsMessage}


### PR DESCRIPTION
I missed these props, fixes #99 