### PR TITLE
feat(react-components): grid column offsets from top

### DIFF
--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -24,6 +24,7 @@ type Props = {
     noResultsMessage?: string | JSX.Element
     initialGifs?: IGif[]
     useTransform?: boolean
+    columnOffsets?: number[]
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {}, initialGifs: [] })
@@ -126,6 +127,7 @@ class Grid extends PureComponent<Props, State> {
             width,
             gutter,
             useTransform,
+            columnOffsets,
         } = this.props
         const { gifWidth, gifs, isError, isDoneFetching } = this.state
         const showLoader = fetchGifs && !isDoneFetching
@@ -140,6 +142,7 @@ class Grid extends PureComponent<Props, State> {
                     itemWidth={gifWidth}
                     columns={columns}
                     gutter={gutter}
+                    columnOffsets={columnOffsets}
                 >
                     {gifs.map(gif => (
                         <Gif

--- a/packages/react-components/src/components/masonry-grid.tsx
+++ b/packages/react-components/src/components/masonry-grid.tsx
@@ -11,8 +11,17 @@ type Props = {
     children: ReactNode
     itemHeights: number[]
     itemWidth: number
+    columnOffsets?: number[]
 }
-const MasonryGrid = ({ columns, gutter, useTransform = true, itemWidth, itemHeights, children }: Props) => {
+const MasonryGrid = ({
+    columns,
+    gutter,
+    useTransform = true,
+    itemWidth,
+    itemHeights,
+    children,
+    columnOffsets = [],
+}: Props) => {
     const containerStyle: any = {}
     function getChildren() {
         let columnTarget: number
@@ -22,7 +31,8 @@ const MasonryGrid = ({ columns, gutter, useTransform = true, itemWidth, itemHeig
                 position: 'absolute',
             }
             columnTarget = columnHeights.indexOf(Math.min.apply(Math, columnHeights))
-            const top = `${columnHeights[columnTarget]}px`
+            const topOffset = columnOffsets[columnTarget] || 0
+            const top = `${columnHeights[columnTarget] + topOffset}px`
             const left = `${columnTarget * itemWidth + columnTarget * gutter}px`
             if (useTransform) {
                 style.transform = `translate3d(${left}, ${top}, 0)`


### PR DESCRIPTION
a column's top can start with an offset

```jsx
<Grid
    width={width}
    columns={columns}
    fetchGifs={fetchWrapped}
    columnOffsets={[0,0,100,100]} // start the 3rd and 4th column 100 pixels from the top
/>