### PR TITLE
fix(react-components): column offsets in masonry

### DIFF
--- a/packages/react-components/src/components/masonry-grid.tsx
+++ b/packages/react-components/src/components/masonry-grid.tsx
@@ -1,7 +1,7 @@
 import React, { memo, ReactNode } from 'react'
 
-function fillArray(length: any) {
-    return Array.apply(null, Array(length)).map(() => 0)
+function fillArray(length: number, columnOffsets: number[] = []) {
+    return Array.apply(null, Array(length)).map((_, index) => columnOffsets[index] || 0)
 }
 
 type Props = {
@@ -25,14 +25,13 @@ const MasonryGrid = ({
     const containerStyle: any = {}
     function getChildren() {
         let columnTarget: number
-        const columnHeights: number[] = fillArray(columns)
+        const columnHeights: number[] = fillArray(columns, columnOffsets)
         const result = React.Children.map(children, (child: React.ReactNode, index: number) => {
             const style: any = {
                 position: 'absolute',
             }
             columnTarget = columnHeights.indexOf(Math.min.apply(Math, columnHeights))
-            const topOffset = columnOffsets[columnTarget] || 0
-            const top = `${columnHeights[columnTarget] + topOffset}px`
+            const top = `${columnHeights[columnTarget]}px`
             const left = `${columnTarget * itemWidth + columnTarget * gutter}px`
             if (useTransform) {
                 style.transform = `translate3d(${left}, ${top}, 0)`


### PR DESCRIPTION
When using column offsets*, the offset needed to be incorporated into the initial values in order to determine the column target correctly. 

Bug: 
<img width="689" alt="Screen Shot 2020-07-09 at 12 34 44 PM" src="https://user-images.githubusercontent.com/448767/87083377-5cfb5900-c1e1-11ea-9b9e-57ace627a07c.png">

* Column offsets are an edge case where you need to push the start of the columns down, a requirement for giphy.com to show a TV in a grid 