### PR TITLE
fix(attribution): handle an empty user object

### DIFF
--- a/packages/components/src/components/attribution/index.tsx
+++ b/packages/components/src/components/attribution/index.tsx
@@ -28,7 +28,7 @@ const verifiedBadge = css`
 type Props = { gif: IGif; className?: string }
 const Attribution = ({ gif, className }: Props) => {
     const { user } = gif
-    if (!user) {
+    if (!user?.username && !user?.display_name) {
         return null
     }
     const { display_name, username } = user

--- a/packages/react-components/src/components/attribution/index.tsx
+++ b/packages/react-components/src/components/attribution/index.tsx
@@ -28,7 +28,7 @@ const verifiedBadge = css`
 type Props = { gif: IGif; className?: string }
 const Attribution = ({ gif, className }: Props) => {
     const { user } = gif
-    if (!user) {
+    if (!user?.username && !user?.display_name) {
         return null
     }
     const { display_name, username } = user


### PR DESCRIPTION
In an api response, sometimes a user object is an empty object, sometimes it's null. Handle the empty object scenario 