### PR TITLE
Update README.md

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -69,9 +69,11 @@ const makeGrid = (targetEl: HTMLElement) => {
     const resizeRender = throttle(500, render)
     window.addEventListener('resize', resizeRender, false)
     const remove = render()
-    return () => {
-        remove()
-        window.removeEventListener('resize', resizeRender, false)
+    return {
+        remove: () => {
+            remove()
+            window.removeEventListener('resize', resizeRender, false)
+        }
     }
 }
 


### PR DESCRIPTION
The example code for Grid has an error with the `remove` function. The return of `makeGrid` returns an actual function. With the code the way it is, you'd need to call `grid()` to get the remove to fire. Not `grid.remove()`. I've updated the example code to return an object parameter called `remove` that is a function that can be called how the `grid.remove()` pattern is attempting at the end.