### PR TITLE
fix(fetch-api): don't cache random requests in memory

### DIFF
--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-dupe-class-members */
-import qs from 'qs'
 import cookie from 'cookie'
+import qs from 'qs'
 import { normalizeGif, normalizeGifs } from './normalize/gif'
 import {
     CategoriesOptions,
@@ -124,7 +124,9 @@ export class GiphyFetch {
      * @returns {Promise<GifResult>}
      **/
     random(options?: RandomOptions): Promise<GifResult> {
-        return request(`${getType(options)}/random?${this.getQS(options)}`, normalizeGif) as Promise<GifResult>
+        return request(`${getType(options)}/random?${this.getQS(options)}`, normalizeGif, undefined, true) as Promise<
+            GifResult
+        >
     }
 
     /**

--- a/packages/fetch-api/src/request.ts
+++ b/packages/fetch-api/src/request.ts
@@ -10,9 +10,10 @@ const requestMap: { [key: string]: Promise<Result> } = {}
 function request(
     url: string,
     normalizer: (a: any, pingbackType?: PingbackEventType) => any = identity,
-    pingbackType?: PingbackEventType
+    pingbackType?: PingbackEventType,
+    noCache: boolean = false
 ) {
-    if (!requestMap[url]) {
+    if (!requestMap[url] || noCache) {
         const makeRequest = async (): Promise<Result> => {
             let fetchError: FetchError
             try {


### PR DESCRIPTION
We cache requests based on url, something we don't want to do for `random()`, adding an internal option to skip the cache