### PR TITLE
feat(no-link): grid and carousel components accept the noLink prop

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -25,15 +25,16 @@ renderGrid({ width: 800, fetchGifs }, targetEl)
 
 _renderGrid options_
 
-| _prop_                                  | _type_                                   | _default_ | _description_                                                            |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| width                                   | `number`                                 | undefined | The width of the grid                                                    |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| columns                                 | `number`                                 | 3         | The number of columns in the grid                                        |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| noResultsMessage                        | `string || element`                      | undefined | Customise the "No results" message                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                            |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| _prop_                                  | _type_                                   | _default_ | _description_                                                                                         |
+| --------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| width                                   | `number`                                 | undefined | The width of the grid                                                                                 |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                              |
+| columns                                 | `number`                                 | 3         | The number of columns in the grid                                                                     |
+| gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
+| noResultsMessage                        | `string || element`                      | undefined | Customise the "No results" message                                                                    |
+| noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                                                         |
+| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                             |
 
 ### Thorough Example
 
@@ -73,7 +74,7 @@ const makeGrid = (targetEl: HTMLElement) => {
         remove: () => {
             remove()
             window.removeEventListener('resize', resizeRender, false)
-        }
+        },
     }
 }
 
@@ -88,20 +89,25 @@ grid.remove()
 
 _renderCarousel options_
 
-| property                                | type                                     | default   | description                                                              |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| noResultsMessage                        | `string || element`                      | undefined | Customise the "No results" message                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                            |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| property                                | type                                     | default   | description                                                                                           |
+| --------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                                               |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                              |
+| gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
+| noResultsMessage                        | `string || element`                      | undefined | Customise the "No results" message                                                                    |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                                                         |
+| noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                             |
 
 ```typescript
 import { renderCarousel } from '@giphy/js-components'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+
+// create a GiphyFetch with your api key
+const gf = new GiphyFetch('your api key')
 
 // Creating a grid with window resizing and remove-ability
-export const vanillaJSCarousel = (mountNode: HTMLElement) => {
+const vanillaJSCarousel = (mountNode: HTMLElement) => {
     renderCarousel(
         {
             gifHeight: 200,
@@ -111,6 +117,33 @@ export const vanillaJSCarousel = (mountNode: HTMLElement) => {
         },
         mountNode
     )
+}
+```
+
+## Gif
+
+_Gif props_
+
+| _prop_                                  | _type_    | _default_          | _description_                                                                                         |
+| --------------------------------------- | --------- | ------------------ | ----------------------------------------------------------------------------------------------------- |
+| gif                                     | `IGif`    | undefined          | The gif to display                                                                                    |
+| width                                   | `number`  | undefined          | The width of the gif                                                                                  |
+| backgroundColor                         | `string`  | random giphy color | The background of the gif before it loads                                                             |
+| [hideAttribution](#attribution-overlay) | `boolean` | false              | Hide the user attribution that appears over a GIF                                                     |
+| noLink                                  | `boolean` | false              | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| [Gif Events](#gif-events)               | \*        | \*                 | see below                                                                                             |
+
+```typescript
+import { renderGif } from '@giphy/js-components'
+import { GiphyFetch } from '@giphy/js-fetch-api'
+
+// create a GiphyFetch with your api key
+const gf = new GiphyFetch('your api key')
+
+const vanillaJSGif = async (mountNode: HTMLElement) => {
+    // render a single gif
+    const { data: gif1 } = await gf.gif('fpXxIjftmkk9y')
+    renderGif({ gif: gif1, width: 300 }, mountNode)
 }
 ```
 

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -42,6 +42,7 @@ type Props = {
     onGifsFetched?: (gifs: IGif[]) => void
     noResultsMessage?: string | JSX.Element
     hideAttribution?: boolean
+    noLink?: boolean
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
@@ -112,6 +113,7 @@ class Carousel extends Component<Props, State> {
             user,
             noResultsMessage,
             hideAttribution,
+            noLink,
         }: Props,
         { gifs }: State
     ) {
@@ -141,6 +143,7 @@ class Carousel extends Component<Props, State> {
                             onGifRightClick={onGifRightClick}
                             user={user}
                             hideAttribution={hideAttribution}
+                            noLink={noLink}
                         />
                     )
                 })}

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -24,6 +24,7 @@ type Props = {
     onGifsFetchError?: (e: Error) => void
     noResultsMessage?: string | JSX.Element
     hideAttribution?: boolean
+    noLink?: boolean
 } & EventProps
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
 
@@ -145,6 +146,7 @@ class Grid extends Component<Props, State> {
             user,
             noResultsMessage,
             hideAttribution,
+            noLink,
         }: Props,
         { gifWidth, gifs, isError, isDoneFetching }: State
     ) {
@@ -165,6 +167,7 @@ class Grid extends Component<Props, State> {
                             onGifRightClick={onGifRightClick}
                             user={user}
                             hideAttribution={hideAttribution}
+                            noLink={noLink}
                         />
                     ))}
                     {!showLoader && gifs.length === 0 && noResultsMessage}

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -46,26 +46,28 @@ ReactDOM.render(<Grid width={800} columns={3} gutter={6} fetchGifs={fetchGifs} /
 
 See this [codesanbox](https://codesandbox.io/s/giphy-web-sdk-ssr-with-nextjs-irv19) for an example of SSR with next.js
 
-| _prop_                                  | _type_                                   | _default_ | _description_                                                            |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| width                                   | `number`                                 | undefined | The width of the grid                                                    |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| columns                                 | `number`                                 | 3         | The number of columns in the grid                                        |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| noResultsMessage                        | `string || component`                    | undefined | Customise the "No results" message                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                        |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| _prop_                                  | _type_                                   | _default_ | _description_                                                                                         |
+| --------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| width                                   | `number`                                 | undefined | The width of the grid                                                                                 |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                              |
+| columns                                 | `number`                                 | 3         | The number of columns in the grid                                                                     |
+| gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
+| noResultsMessage                        | `string || component`                    | undefined | Customise the "No results" message                                                                    |
+| noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                                                     |
+| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                             |
 
 ## Carousel
 
-| _prop_                                  | _type_                                   | _default_ | _description_                                                            |
-| --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------ |
-| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                  |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api` |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                       |
-| noResultsMessage                        | `string || component`                    | undefined | Customise the "No results" message                                       |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                        |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                |
+| _prop_                                  | _type_                                   | _default_ | _description_                                                                                         |
+| --------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                                               |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                              |
+| gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
+| noResultsMessage                        | `string || component`                    | undefined | Customise the "No results" message                                                                    |
+| noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                                                     |
+| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                             |
 
 See [codesandbox](https://codesandbox.io/s/giphyreact-components-hbmcf?from-embed) for runnable code
 
@@ -86,14 +88,15 @@ ReactDOM.render(<Carousel gifHeight={200} gutter={6} fetchGifs={fetchGifs} />, t
 
 _Gif props_
 
-| _prop_                                  | _type_                                     | _default_          | _description_                                     |
-| --------------------------------------- | ------------------------------------------ | ------------------ | ------------------------------------------------- |
-| gif                                     | `IGif`                                     | undefined          | The gif to display                                |
-| width                                   | `number`                                   | undefined          | The width of the gif                              |
-| backgroundColor                         | `string`                                   | random giphy color | The background of the gif before it loads         |
-| [hideAttribution](#attribution-overlay) | `boolean`                                  | false              | Hide the user attribution that appears over a GIF |
-| [overlay](#gif-overlay)                 | `(props: GifOverlayProps):ReactType => {}` | undefined          | see below                                         |
-| [Gif Events](#gif-events)               | \*                                         | \*                 | see below                                         |
+| _prop_                                  | _type_                                     | _default_          | _description_                                                                                         |
+| --------------------------------------- | ------------------------------------------ | ------------------ | ----------------------------------------------------------------------------------------------------- |
+| gif                                     | `IGif`                                     | undefined          | The gif to display                                                                                    |
+| width                                   | `number`                                   | undefined          | The width of the gif                                                                                  |
+| backgroundColor                         | `string`                                   | random giphy color | The background of the gif before it loads                                                             |
+| [hideAttribution](#attribution-overlay) | `boolean`                                  | false              | Hide the user attribution that appears over a GIF                                                     |
+| noLink                                  | `boolean`                                  | false              | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| [overlay](#gif-overlay)                 | `(props: GifOverlayProps):ReactType => {}` | undefined          | see below                                                                                             |
+| [Gif Events](#gif-events)               | \*                                         | \*                 | see below                                                                                             |
 
 See [codesandbox](https://codesandbox.io/s/giphyreact-components-hbmcf?from-embed) for runnable code
 

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -53,6 +53,7 @@ type Props = {
     onGifsFetched?: (gifs: IGif[]) => void
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
+    noLink?: boolean
     noResultsMessage?: string | JSX.Element
     initialGifs?: IGif[]
 } & EventProps
@@ -127,6 +128,7 @@ class Carousel extends PureComponent<Props, State> {
             user,
             overlay,
             hideAttribution,
+            noLink,
             noResultsMessage,
         } = this.props
         const { gifs, isDoneFetching } = this.state
@@ -157,6 +159,7 @@ class Carousel extends PureComponent<Props, State> {
                             user={user}
                             overlay={overlay}
                             hideAttribution={hideAttribution}
+                            noLink={noLink}
                         />
                     )
                 })}

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -21,6 +21,7 @@ type Props = {
     onGifsFetchError?: (e: Error) => void
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
+    noLink?: boolean
     noResultsMessage?: string | JSX.Element
     initialGifs?: IGif[]
     useTransform?: boolean
@@ -122,6 +123,7 @@ class Grid extends PureComponent<Props, State> {
             user,
             overlay,
             hideAttribution,
+            noLink,
             noResultsMessage,
             columns,
             width,
@@ -156,6 +158,7 @@ class Grid extends PureComponent<Props, State> {
                             user={user}
                             overlay={overlay}
                             hideAttribution={hideAttribution}
+                            noLink={noLink}
                         />
                     ))}
                 </MasonryGrid>


### PR DESCRIPTION
- add `noLink` prop to `Grid` and `Carousel` to be passed to `Gif` components 
- update docs

`noLink` renders the `Gif` component with a `div` instead of an `a` tag. The user will define gif click functionality with `onGifClick`. 