### PR TITLE
Wrong type for subcategories

### DIFF
--- a/packages/fetch-api/src/result-types.ts
+++ b/packages/fetch-api/src/result-types.ts
@@ -27,7 +27,7 @@ export interface ICategory {
     gif?: IGif
     name: string
     name_encoded: string
-    subcategories: ICategory
+    subcategories: ICategory[]
 }
 export interface CategoriesResult extends Result {
     data: ICategory[]


### PR DESCRIPTION
Subcategories in ICategory interface changed from ICategory to ICategory[]