### PR TITLE
feat(fetch-api): related stickers option

### DIFF
--- a/packages/fetch-api/README.md
+++ b/packages/fetch-api/README.md
@@ -108,7 +108,7 @@ Fetch related gifs based on the id of a gif
 related(id: string, options?: RelatedOptions): Promise<GifsResult>
 ```
 
-> Options: [Pagination Options](#pagination-options)
+> Options: [Pagination Options](#pagination-options), [Type Option](#type-option)
 
 ##### Example:
 
@@ -150,7 +150,7 @@ random(options?: RandomOptions): Promise<GifResult>
 | :----- | :----- | :---------------------------------- | :-------: |
 | _tag_  | string | The GIF tag to limit randomness by. | undefined |
 
-> Other Options: [Type Option](#type-option)
+> Options: [Type Option](#type-option)
 
 ##### Example:
 

--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -125,6 +125,11 @@ describe('response parsing', () => {
         const { data } = await gf.related('12345')
         testDummyGif(data[0])
     })
+    test('related', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
+        const { data } = await gf.related('12345', { type: 'stickers' })
+        testDummyGif(data[0])
+    })
     test('emoji', async () => {
         fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
         const { data } = await gf.emoji()

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -130,7 +130,10 @@ export class GiphyFetch {
      * @returns {Promise<GifsResult>}
      **/
     related(id: string, options?: RelatedOptions): Promise<GifsResult> {
-        return request(`gifs/related?${this.getQS({ gif_id: id, ...options })}`, normalizeGifs) as Promise<GifsResult>
+        return request(
+            `${options?.type === 'stickers' ? 'stickers' : 'gifs'}/related?${this.getQS({ gif_id: id, ...options })}`,
+            normalizeGifs
+        ) as Promise<GifsResult>
     }
 }
 export default GiphyFetch

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -23,7 +23,9 @@ export interface PaginationOptions {
 }
 export interface CategoriesOptions extends PaginationOptions {}
 export interface SubcategoriesOptions extends PaginationOptions {}
-export interface RelatedOptions extends PaginationOptions {}
+export interface RelatedOptions extends PaginationOptions {
+    type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
+}
 
 export interface TrendingOptions extends PaginationOptions, TypeOption {
     rating?: Rating


### PR DESCRIPTION
Add a type option for the related endpoint. type can be `gifs` or `stickers`