### PR TITLE
feat(react-components): border radius

### DIFF
--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -44,6 +44,7 @@ type Props = {
     noResultsMessage?: string | JSX.Element
     hideAttribution?: boolean
     noLink?: boolean
+    borderRadius?: number
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
@@ -115,6 +116,7 @@ class Carousel extends Component<Props, State> {
             noResultsMessage,
             hideAttribution,
             noLink,
+            borderRadius,
         }: Props,
         { gifs }: State
     ) {
@@ -146,6 +148,7 @@ class Carousel extends Component<Props, State> {
                                 user={user}
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
+                                borderRadius={borderRadius}
                             />
                         )
                     })}

--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -60,6 +60,7 @@ type GifProps = {
     user?: Partial<IUser>
     hideAttribution?: boolean
     noLink?: boolean
+    borderRadius?: number
 }
 
 export type Props = GifProps & EventProps
@@ -81,6 +82,7 @@ const Gif = ({
     backgroundColor,
     hideAttribution = false,
     noLink = false,
+    borderRadius = 4,
 }: Props) => {
     // only fire seen once per gif id
     const [hasFiredSeen, setHasFiredSeen] = useState(false)
@@ -194,6 +196,12 @@ const Gif = ({
             ? `url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADgAAAA4AQMAAACSSKldAAAABlBMVEUhIiIWFhYoSqvJAAAAGElEQVQY02MAAv7///8PWxqIPwDZw5UGABtgwz2xhFKxAAAAAElFTkSuQmCC') 0 0`
             : defaultBgColor.current)
 
+    const borderRadiusCss = borderRadius
+        ? css`
+              border-radius: ${borderRadius}px;
+              overflow: hidden;
+          `
+        : ''
     return (
         <Container
             href={noLink ? undefined : gif.url}
@@ -201,7 +209,7 @@ const Gif = ({
                 width,
                 height,
             }}
-            className={cx(Gif.className, gifCss, className)}
+            className={cx(Gif.className, gifCss, borderRadiusCss, className)}
             onMouseOver={onMouseOver}
             onMouseLeave={onMouseLeave}
             onClick={onClick}

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -26,6 +26,7 @@ type Props = {
     noResultsMessage?: string | JSX.Element
     hideAttribution?: boolean
     noLink?: boolean
+    borderRadius?: number
 } & EventProps
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
 
@@ -148,6 +149,7 @@ class Grid extends Component<Props, State> {
             noResultsMessage,
             hideAttribution,
             noLink,
+            borderRadius,
         }: Props,
         { gifWidth, gifs, isError, isDoneFetching }: State
     ) {
@@ -170,6 +172,7 @@ class Grid extends Component<Props, State> {
                                 user={user}
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
+                                borderRadius={borderRadius}
                             />
                         ))}
                         {!showLoader && gifs.length === 0 && noResultsMessage}

--- a/packages/react-components/src/components/attribution/overlay.tsx
+++ b/packages/react-components/src/components/attribution/overlay.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled'
+import { IGif } from '@giphy/js-types'
 import React, { useRef } from 'react'
 import Attribution_ from '.'
 import { GifOverlayProps } from '../gif'
-import { IGif } from '@giphy/js-types'
 
 const Background = styled.div`
     background: linear-gradient(rgba(0, 0, 0, 0), rgba(18, 18, 18, 0.6));

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -58,6 +58,7 @@ type Props = {
     noResultsMessage?: string | JSX.Element
     initialGifs?: IGif[]
     backgroundColor?: string
+    borderRadius?: number
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {}, initialGifs: [] })
@@ -133,6 +134,7 @@ class Carousel extends PureComponent<Props, State> {
             noLink,
             noResultsMessage,
             backgroundColor,
+            borderRadius,
         } = this.props
         const { gifs, isDoneFetching } = this.state
         const showLoader = fetchGifs && !isDoneFetching
@@ -156,6 +158,7 @@ class Carousel extends PureComponent<Props, State> {
                                 overlay={overlay}
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
+                                borderRadius={borderRadius}
                                 backgroundColor={backgroundColor}
                             />
                         )

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/core'
 import styled from '@emotion/styled'
 import { giphyBlue, giphyGreen, giphyPurple, giphyRed, giphyYellow } from '@giphy/js-brand'
 import { IGif, ImageAllTypes, IUser } from '@giphy/js-types'
@@ -8,8 +9,14 @@ import AttributionOverlay from './attribution/overlay'
 import VerifiedBadge from './attribution/verified-badge'
 import { PingbackContext } from './pingback-context-manager'
 
-const GifContainer = styled.div`
+const GifContainer = styled.div<{ borderRadius?: number }>`
     display: block;
+    ${(props) =>
+        props.borderRadius &&
+        css`
+            border-radius: ${props.borderRadius}px;
+            overflow: hidden;
+        `}
     img {
         display: block;
     }
@@ -28,7 +35,7 @@ export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLOR
 
 const hoverTimeoutDelay = 200
 
-type ContainerProps = HTMLProps<HTMLElement> & { href?: string }
+type ContainerProps = HTMLProps<HTMLElement> & { href?: string; borderRadius: number }
 const Container = (props: ContainerProps) => (
     <GifContainer as={props.href ? 'a' : 'div'} {...(props as HTMLProps<HTMLDivElement>)} />
 )
@@ -60,6 +67,7 @@ type GifProps = {
     overlay?: ReactType<GifOverlayProps>
     hideAttribution?: boolean
     noLink?: boolean
+    borderRadius?: number
     style?: any
 }
 
@@ -86,6 +94,7 @@ const Gif = ({
     overlay,
     hideAttribution = false,
     noLink = false,
+    borderRadius = 4,
     style,
 }: Props) => {
     // only fire seen once per gif id
@@ -222,6 +231,7 @@ const Gif = ({
                 height,
                 ...style,
             }}
+            borderRadius={borderRadius}
             className={[Gif.className, className].join(' ')}
             onMouseOver={onMouseOver}
             onMouseLeave={onMouseLeave}

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -28,6 +28,7 @@ type Props = {
     useTransform?: boolean
     columnOffsets?: number[]
     backgroundColor?: string
+    borderRadius?: number
 } & EventProps
 
 const Loader = styled(DotsLoader)<{ isFirstLoad: boolean }>`
@@ -130,6 +131,7 @@ class Grid extends PureComponent<Props, State> {
             overlay,
             hideAttribution,
             noLink,
+            borderRadius,
             noResultsMessage,
             columns,
             width,
@@ -168,6 +170,7 @@ class Grid extends PureComponent<Props, State> {
                                 backgroundColor={backgroundColor}
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
+                                borderRadius={borderRadius}
                             />
                         ))}
                     </MasonryGrid>

--- a/packages/react-components/stories/gif.stories.tsx
+++ b/packages/react-components/stories/gif.stories.tsx
@@ -12,7 +12,17 @@ const eventAction = (event: string) => (gif: IGif) => {
     action(`Gif ${event} for ${gif.id}`)()
 }
 
-const GifDemo = ({ id, width, noLink }: { id: string; width: number; noLink?: boolean }) => {
+const GifDemo = ({
+    id,
+    width,
+    noLink,
+    borderRadius,
+}: {
+    id: string
+    width: number
+    noLink?: boolean
+    borderRadius?: number
+}) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = async () => {
@@ -27,6 +37,7 @@ const GifDemo = ({ id, width, noLink }: { id: string; width: number; noLink?: bo
     return gif ? (
         <GifComponent
             key={`gif-${noLink}`}
+            borderRadius={borderRadius}
             gif={gif}
             width={width}
             noLink={noLink}
@@ -44,6 +55,15 @@ export default {
 
 export const Gif = () => (
     <GifDemo id={text('id', 'ZEU9ryYGZzttn0Cva7')} width={number('width', 300)} noLink={boolean('noLink', false)} />
+)
+
+export const GifNoBorderRadius = () => (
+    <GifDemo
+        id={text('id', 'ZEU9ryYGZzttn0Cva7')}
+        borderRadius={0}
+        width={number('width', 300)}
+        noLink={boolean('noLink', false)}
+    />
 )
 export const Sticker = () => (
     <GifDemo id={text('id', 'l1J9FvenuBnI4GTeg')} width={number('width', 300)} noLink={boolean('noLink', false)} />


### PR DESCRIPTION
By default in `@giphy/react-components`, gif components will now have a border radius. It can be turned off by passing `borderRadius={0}`.

<img width="259" alt="Screen Shot 2021-01-04 at 7 58 27 AM" src="https://user-images.githubusercontent.com/448767/103553677-a52ec780-4e62-11eb-9437-49434266ca89.png">
