### PR TITLE
feat(components/react-components): on loaded classname

### DIFF
--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -86,6 +86,8 @@ const Gif = ({
 }: Props) => {
     // only fire seen once per gif id
     const [hasFiredSeen, setHasFiredSeen] = useState(false)
+    // classname to target animations on image load
+    const [loadedClassname, setLoadedClassName] = useState('')
     // hovered is for the gif overlay
     const [isHovered, setHovered] = useState(false)
     // only show the gif if it's on the screen
@@ -159,6 +161,7 @@ const Gif = ({
             fullGifObserver.current.observe(container.current)
         }
         onGifVisible(gif, e) // gif is visible, perhaps just partially
+        setLoadedClassName(Gif.imgLoadedClassName)
     }
 
     useEffect(() => {
@@ -219,7 +222,7 @@ const Gif = ({
                 <picture>
                     <source type="image/webp" srcSet={rendition.webp} />
                     <img
-                        className={Gif.imgClassName}
+                        className={[Gif.imgClassName, loadedClassname].join(' ')}
                         src={showGif ? rendition.url : placeholder}
                         style={{ background }}
                         width={width}
@@ -238,5 +241,6 @@ const Gif = ({
 
 Gif.className = 'giphy-gif'
 Gif.imgClassName = 'giphy-gif-img'
+Gif.imgLoadedClassName = 'giphy-img-loaded'
 
 export default Gif

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -104,6 +104,8 @@ const Gif = ({
     // only show the gif if it's on the screen
     // if we can't use the dom (SSR), then we show the gif by default
     const [showGif, setShowGif] = useState(!canUseDOM)
+    // classname to target animations on image load
+    const [loadedClassname, setLoadedClassName] = useState('')
     // the background color shouldn't change unless it comes from a prop or we have a sticker
     const defaultBgColor = useRef(getColor())
     // the a tag the media is rendered into
@@ -185,6 +187,7 @@ const Gif = ({
     const onImageLoad = (e: SyntheticEvent<HTMLElement, Event>) => {
         watchGif()
         onGifVisible(gif, e) // gif is visible, perhaps just partially
+        setLoadedClassName(Gif.imgLoadedClassName)
     }
 
     useEffect(() => {
@@ -244,7 +247,7 @@ const Gif = ({
                     <img
                         ref={image}
                         suppressHydrationWarning
-                        className={Gif.imgClassName}
+                        className={[Gif.imgClassName, loadedClassname].join(' ')}
                         src={showGif ? rendition.url : placeholder}
                         style={{ background }}
                         width={width}
@@ -261,5 +264,6 @@ const Gif = ({
 
 Gif.className = 'giphy-gif'
 Gif.imgClassName = 'giphy-gif-img'
+Gif.imgLoadedClassName = 'giphy-img-loaded'
 
 export default Gif


### PR DESCRIPTION
Add a class name to the `Gif` component's img element after the img loads. This lets you target a transition in animation for any `Gif` component. 


Styled Component example of animating `Gif` components on a `Grid`:
```tsx
import { Gif, Grid } from '@giphy/react-components'

const growIn = keyframes`
    0% {
      transform: scale(0.6);
      opacity: 0;
    };  
    
    100% {
        transform: scale(1);
        opacity: 1;
    }
`

const GridWithAniimation = styled(Grid)`
    .${Gif.imgClassName} {
        transform: scale(0.6);
        opacity: 0;
    }
    .${Gif.imgLoadedClassName} {
        animation: ${growIn} ease-out 250ms forwards;
    }
`
