### PR TITLE
Feat/exclude dynamic results

### DIFF
--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -148,6 +148,15 @@ describe('response parsing', () => {
     test('text trending', async () => {
         fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
         const { data } = await gf.trending({ type: 'text' })
+        const [req] = fetchMock.mock.calls
+        expect((req[0] as string).indexOf(`excludeDynamicResults`)).toEqual(-1)
+        testDummyGif(data[0])
+    })
+    test('text search', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(gifsResponse))
+        const { data } = await gf.search('hi', { type: 'text' })
+        const [req] = fetchMock.mock.calls
+        expect((req[0] as string).indexOf(`excludeDynamicResults`)).toBeGreaterThan(-1)
         testDummyGif(data[0])
     })
     test('response ok with message', async () => {

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -88,7 +88,11 @@ export class GiphyFetch {
      **/
     search(term: string, options: SearchOptions = {}): Promise<GifsResult> {
         const q = options.channel ? `@${options.channel} ${term}` : term
-        const qsParams = this.getQS({ ...options, q })
+        let excludeDynamicResults
+        if (options.type === 'text') {
+            excludeDynamicResults = true
+        }
+        const qsParams = this.getQS({ ...options, q, excludeDynamicResults })
         return request(`${getType(options)}/search?${qsParams}`, normalizeGifs) as Promise<GifsResult>
     }
 

--- a/packages/react-components/src/components/search-bar/context.tsx
+++ b/packages/react-components/src/components/search-bar/context.tsx
@@ -57,14 +57,14 @@ const SearchContextManager = ({ children, options = {}, apiKey, theme, initialTe
     // do a search for a term and optionally a channel
     const setSearch = (term: string) => setTerm(term)
 
-    const searchKey = [term, options.type, channelSearch, activeChannel?.user.username || '']
+    const searchKey = [term, options.type, channelSearch, activeChannel?.user?.username || '']
         .filter((val) => !!val)
         .join(' / ')
 
     // search fetch
     const fetchGifs = async (offset: number) => {
         setIsFetching(true)
-        const result = await gf.search(term, { ...options, offset, channel: activeChannel?.user.username })
+        const result = await gf.search(term, { ...options, offset, channel: activeChannel?.user?.username })
         setIsFetching(false)
         return result
     }

--- a/packages/types/src/channel.ts
+++ b/packages/types/src/channel.ts
@@ -23,6 +23,7 @@ export interface IChannel {
     is_visible: boolean
     is_private: boolean
     is_live: boolean
+    // TODO this seems to be undefined sometimes
     user: IUser
     featured_gif: IGif
     tags: IChannelTag[]


### PR DESCRIPTION
append `excludeDynamicResults` to `text/search` requests 