### PR TITLE
feat(fetch-api): handle synthetic response (api error)

### DIFF
--- a/packages/fetch-api/src/__tests__/api.test.ts
+++ b/packages/fetch-api/src/__tests__/api.test.ts
@@ -46,6 +46,17 @@ const gifResponseWithUser = {
 const category = { name: 'news & politics', name_encoded: 'news-politics' }
 const categoriesResponse = {
     data: [category],
+    meta: {
+        response_id: 'category response id ',
+    },
+}
+
+const syntheticResponse = {
+    data: [],
+    meta: {
+        msg: 'OK',
+        response_id: '',
+    },
 }
 const gf = new GiphyFetchAPI('4OMJYpPoYwVpe')
 const testDummyGif = (gif: IGif) => {
@@ -183,6 +194,15 @@ describe('response parsing', () => {
             await gf.related('12345 dslfjdlskj')
         } catch (error) {
             expect(error.message).toBe('some crazy error')
+        }
+    })
+
+    test('synthetic response', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(syntheticResponse))
+        try {
+            await gf.related('12345 dslfjdlskj')
+        } catch (error) {
+            expect(error.message).toBe('synthetic response')
         }
     })
 })

--- a/packages/fetch-api/src/request.ts
+++ b/packages/fetch-api/src/request.ts
@@ -39,8 +39,13 @@ function request(url: string, normalizer: (a: any) => any = identity, noCache: b
                 })
                 if (response.ok) {
                     const result = (await response.json()) as Result
-                    // if everything is successful, we return here, otherwise an error will be thrown
-                    return normalizer(result)
+                    // no response id is an indiication of a synthetic response
+                    if (!result.meta?.response_id) {
+                        throw { message: `synthetic response` } as ErrorResult
+                    } else {
+                        // if everything is successful, we return here, otherwise an error will be thrown
+                        return normalizer(result)
+                    }
                 } else {
                     let message = DEFAULT_ERROR
                     try {
@@ -54,6 +59,7 @@ function request(url: string, normalizer: (a: any) => any = identity, noCache: b
                         // but the api goes down and sends 400s, so allow a refetch after errorMaxLife
                         requestMap[url].isError = true
                     }
+
                     // we got an error response, throw with the message in the response body json
                     fetchError = new FetchError(`${ERROR_PREFIX}${message}`, response.status, response.statusText)
                 }


### PR DESCRIPTION
If a response has no `response_id`, flag it is an error, even though it's a `200`. @ethanlu any response without a `response_id` is going to throw an error, just want to make sure that this is 100% the right thing to do