### PR TITLE
fix(gif): css tabindex focus css

### DIFF
--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -11,6 +11,9 @@ import { PingbackContext } from './pingback-context-manager'
 
 const gifCss = css`
     display: block;
+    &:focus {
+        outline: unset;
+    }
     img {
         display: block;
     }

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -11,6 +11,9 @@ import { PingbackContext } from './pingback-context-manager'
 
 const GifContainer = styled.div<{ borderRadius?: number }>`
     display: block;
+    &:focus {
+        outline: unset;
+    }
     ${(props) =>
         props.borderRadius &&
         css`


### PR DESCRIPTION
setting tabindex may create a default css border around a gif when it's selected, have it `unset` as the default 