### PR TITLE
Cxp 1023/mixed feed grid spin web

### DIFF
--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -17,7 +17,7 @@ type Props = {
     user: Partial<IUser>
     columns: number
     gutter: number
-    layoutType?: string
+    layoutType?: 'GRID' | 'MIXED_GRID'
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -151,7 +151,7 @@ class Grid extends PureComponent<Props, State> {
         // get the height of each grid item
         const itemHeights = gifs.map((gif) => getGifHeight(gif, gifWidth))
         return (
-            <PingbackContextManager attributes={{ layoutType }}>
+            <PingbackContextManager attributes={{ layout_type: layoutType }}>
                 <div className={className} style={{ width }}>
                     <MasonryGrid
                         itemHeights={itemHeights}

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -17,6 +17,7 @@ type Props = {
     user: Partial<IUser>
     columns: number
     gutter: number
+    layoutType?: string
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void
@@ -142,6 +143,7 @@ class Grid extends PureComponent<Props, State> {
             backgroundColor,
             loaderConfig,
             tabIndex = 0,
+            layoutType = 'GRID',
         } = this.props
         const { gifWidth, gifs, isError, isDoneFetching } = this.state
         const showLoader = !isDoneFetching
@@ -149,7 +151,7 @@ class Grid extends PureComponent<Props, State> {
         // get the height of each grid item
         const itemHeights = gifs.map((gif) => getGifHeight(gif, gifWidth))
         return (
-            <PingbackContextManager attributes={{ layout_type: 'GRID' }}>
+            <PingbackContextManager attributes={{ layoutType }}>
                 <div className={className} style={{ width }}>
                     <MasonryGrid
                         itemHeights={itemHeights}

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -17,7 +17,7 @@ type Props = {
     user: Partial<IUser>
     columns: number
     gutter: number
-    layoutType?: 'GRID' | 'MIXED_GRID'
+    layoutType?: 'GRID' | 'MIXED'
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
     onGifsFetchError?: (e: Error) => void


### PR DESCRIPTION
This PR has the objective to make Grids accept custom `layoutTypes` for pingbacks.

This is required because we are creating the `Mixed Grid`, and we want to separate the pingbacks between Mixed Grids and Normal Grids

Ticket: https://giphypedia.atlassian.net/browse/CXP-1023
Branch on **web-app**: https://github.com/Giphy/web-app/tree/CXP-1023/mixed-feed-grid-spin-web