### PR TITLE
percy(video): don't test video on percy

### DIFF
--- a/packages/react-components/stories/video.stories.tsx
+++ b/packages/react-components/stories/video.stories.tsx
@@ -1,5 +1,6 @@
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { IGif } from '@giphy/js-types'
+import isPercy from '@percy-io/in-percy'
 import { action } from '@storybook/addon-actions'
 import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'
 import React, { useCallback, useEffect, useState } from 'react'
@@ -25,7 +26,8 @@ const VideoDemo = ({ id, width, height, muted }: Props) => {
         fetch()
     }, [fetch, id])
 
-    return gif ? (
+    // percy and our video autoplay aren't cooperating
+    return !isPercy() && gif ? (
         <VideoComponent
             gif={gif}
             width={width}


### PR DESCRIPTION
There's always a difference in Percy visual testing, probably since we force autoplay.