### PR TITLE
feat(fetch-api): export serverUrl

### DIFF
--- a/packages/fetch-api/src/index.ts
+++ b/packages/fetch-api/src/index.ts
@@ -1,9 +1,15 @@
-import { getGiphySDKRequestHeaders, appendGiphySDKRequestHeader } from '@giphy/js-util'
+import { appendGiphySDKRequestHeader, getGiphySDKRequestHeaders } from '@giphy/js-util'
+
+/* istanbul ignore next */
+const gl = ((typeof window !== 'undefined' ? window : global) || {}) as any
+// GIPHY_API_URL is made to override the api url in testing environments
+// must be specified before the packages load
+export const serverUrl = gl.GIPHY_API_URL || 'https://api.giphy.com/v1/'
 
 export { default as GiphyFetch } from './api'
 export * from './option-types'
-export * from './result-types'
 export { gifPaginator } from './paginator'
+export * from './result-types'
 
 const { version } = require('../package.json')
 // since we have multiple SDKs, we're defining a hieracrchy

--- a/packages/fetch-api/src/request.ts
+++ b/packages/fetch-api/src/request.ts
@@ -1,11 +1,9 @@
+import { serverUrl } from '.'
 import FetchError from './fetch-error'
 import { ErrorResult, Result } from './result-types'
+
 export const ERROR_PREFIX = `@giphy/js-fetch-api: `
 export const DEFAULT_ERROR = 'Error fetching'
-
-/* istanbul ignore next */
-const gl = ((typeof window !== 'undefined' ? window : global) || {}) as any
-const serverUrl = gl.GIPHY_API_URL || 'https://api.giphy.com/v1/'
 
 const identity = (i: any) => i
 const requestMap: {

--- a/packages/react-components/src/components/search-bar/context.tsx
+++ b/packages/react-components/src/components/search-bar/context.tsx
@@ -1,4 +1,4 @@
-import { GifsResult, GiphyFetch, SearchOptions } from '@giphy/js-fetch-api'
+import { GifsResult, GiphyFetch, SearchOptions, serverUrl } from '@giphy/js-fetch-api'
 import { IChannel } from '@giphy/js-types'
 import { ThemeProvider } from 'emotion-theming'
 import React, { createContext, ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
@@ -92,9 +92,7 @@ const SearchContextManager = ({ children, options = {}, apiKey, theme, initialTe
     const fetchChannelSearch = useCallback(
         async (offset: number) => {
             const result = await fetch(
-                `https://api.giphy.com/v1/channels/search?q=${encodeURIComponent(
-                    channelSearch
-                )}&offset=${offset}&api_key=${apiKey}`
+                `${serverUrl}channels/search?q=${encodeURIComponent(channelSearch)}&offset=${offset}&api_key=${apiKey}`
             )
             const { data } = await result.json()
             return data as IChannel[]
@@ -103,7 +101,7 @@ const SearchContextManager = ({ children, options = {}, apiKey, theme, initialTe
     )
     useEffect(() => {
         const fetchTrendingSearches = async () => {
-            const result = await fetch(`https://api.giphy.com/v1/trending/searches?api_key=${apiKey}`)
+            const result = await fetch(`${serverUrl}trending/searches?api_key=${apiKey}`)
             const { data } = await result.json()
             setTrendingSearches(data || [])
         }


### PR DESCRIPTION
DRY and for testing environments that use GIPHY_API_URL