### PR TITLE
feat(react-components): custom loader for grid

### DIFF
--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -32,9 +32,10 @@ type Props = {
     borderRadius?: number
     tabIndex?: number
     loaderConfig?: IntersectionObserverInit
+    loader?: ElementType
 } & EventProps
 
-const Loader = styled(DotsLoader)<{ isFirstLoad: boolean }>`
+const Loader = styled.div<{ isFirstLoad: boolean }>`
     opacity: ${(props) => (props.isFirstLoad ? 0 : 1)};
 `
 
@@ -144,6 +145,7 @@ class Grid extends PureComponent<Props, State> {
             loaderConfig,
             tabIndex = 0,
             layoutType = 'GRID',
+            loader: LoaderVisual = DotsLoader,
         } = this.props
         const { gifWidth, gifs, isError, isDoneFetching } = this.state
         const showLoader = !isDoneFetching
@@ -186,7 +188,9 @@ class Grid extends PureComponent<Props, State> {
                     ) : (
                         showLoader && (
                             <Observer onVisibleChange={this.onLoaderVisible} config={loaderConfig}>
-                                <Loader isFirstLoad={isFirstLoad} className={Grid.loaderClassName} />
+                                <Loader isFirstLoad={isFirstLoad}>
+                                    <LoaderVisual className={Grid.loaderClassName} />
+                                </Loader>
                             </Observer>
                         )
                     )}

--- a/packages/react-components/stories/grid.stories.tsx
+++ b/packages/react-components/stories/grid.stories.tsx
@@ -3,7 +3,7 @@ import { GiphyFetch } from '@giphy/js-fetch-api'
 import isPercy from '@percy-io/in-percy'
 import { boolean, number, withKnobs } from '@storybook/addon-knobs'
 import fetchMock from 'fetch-mock'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { ElementType, useEffect, useRef, useState } from 'react'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { throttle } from 'throttle-debounce'
 import { GifOverlayProps, Grid as GridComponent } from '../src'
@@ -35,7 +35,7 @@ const NoResultsContainer = styled.div`
 
 const Overlay = ({ gif, isHovered }: GifOverlayProps) => <OverlayContainer>{isHovered ? gif.id : ''}</OverlayContainer>
 
-export const Grid = () => {
+export const Grid = ({ loader }: { loader: ElementType }) => {
     const [term, setTerm] = useState('always sunny')
     const [width, setWidth] = useState(innerWidth)
     const onResize = throttle(500, () => setWidth(innerWidth))
@@ -74,6 +74,7 @@ export const Grid = () => {
                     columns={columns}
                     gutter={gutter}
                     noResultsMessage={NoResults}
+                    loader={loader}
                     fetchGifs={fetchGifs}
                     overlay={boolean('show overlay', true) ? Overlay : undefined}
                 />
@@ -81,6 +82,8 @@ export const Grid = () => {
         </>
     )
 }
+
+export const GridCustomLoader = () => <Grid loader={() => <h1 style={{ textAlign: 'center' }}> 🌀 </h1>} />
 
 export const GridAPIError = () => {
     const [width, setWidth] = useState(innerWidth)


### PR DESCRIPTION
Enable a custom loader 

```jsx
<Grid
    key={term}
    width={width}
    columns={columns}
    loader={() => <h1 style={{ textAlign: 'center' }}> 🌀 </h1>} 
    fetchGifs={fetchGifs}
/>
```