### PR TITLE
Feat/video cc support

### DIFF
--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -250,6 +250,8 @@ _Video props_
 | hideMute           | `boolean`                  | undefined | if controls is true, hides the mute button       |
 | hidePlayPause      | `boolean`                  | undefined | if controls is true, hides the play/pause button |
 | persistentControls | `boolean`                  | undefined | don't hide controls when hovering away           |
+| ccEnabled          | `boolean`                  | false     | if true, show captions                           |
+| ccLanguage         | `string`                   | 'en'      | the closed caption language                      |
 | onUserMuted        | `(muted: boolean) => void` | undefined | fired when the user toggles the mute state       |
 
 ```tsx

--- a/packages/react-components/src/components/video/progress-bar.tsx
+++ b/packages/react-components/src/components/video/progress-bar.tsx
@@ -11,6 +11,9 @@ const Bar = styled.div<{ barHeight: number }>`
     bottom: 0;
     left: 0;
     opacity: 0.95;
+    @media only percy {
+        opacity: 0;
+    }
 `
 const ProgressBar = ({ videoEl }: { videoEl: HTMLVideoElement }) => {
     useRaf(2147483647, 100)

--- a/packages/react-components/src/components/video/video.tsx
+++ b/packages/react-components/src/components/video/video.tsx
@@ -18,6 +18,8 @@ const Network = {
     NO_SOURCE: 3,
 }
 
+type IVideo = NonNullable<IGif['video']>
+
 type Props = {
     onStateChange?: (state: MEDIA_STATE) => void
     onTimeUpdate?: (playhead: number) => void
@@ -32,6 +34,8 @@ type Props = {
     onQuartile?: (quartile: QuartileEvent) => void
     onMuted?: (isMuted: boolean) => void
     muted?: boolean
+    ccEnabled?: boolean
+    ccLanguage?: keyof IVideo['captions']
     loop?: boolean
     gif: IGif
     width: number
@@ -41,6 +45,8 @@ type Props = {
 }
 const Video = ({
     muted,
+    ccEnabled = false,
+    ccLanguage = 'en',
     loop = true,
     onStateChange,
     onTimeUpdate,
@@ -217,9 +223,10 @@ const Video = ({
             }
         }
     }, [_onPlaying, _onPaused, _onError, _onTimeUpdate, _onCanPlay, _onEnded, _onWaiting, _onEndFullscreen])
-
+    const captionSrc = gif.video?.captions[ccLanguage]?.vtt
     return media?.url ? (
         <video
+            crossOrigin="anonymous"
             draggable={true}
             className={className}
             width={width}
@@ -229,7 +236,11 @@ const Video = ({
             playsInline
             ref={videoEl}
             src={media?.url}
-        />
+        >
+            {ccEnabled && captionSrc && (
+                <track label="English" kind="subtitles" srcLang={ccLanguage} src={captionSrc} default />
+            )}
+        </video>
     ) : null
 }
 

--- a/packages/react-components/src/components/video/video.tsx
+++ b/packages/react-components/src/components/video/video.tsx
@@ -35,7 +35,7 @@ type Props = {
     onMuted?: (isMuted: boolean) => void
     muted?: boolean
     ccEnabled?: boolean
-    ccLanguage?: keyof IVideo['captions']
+    ccLanguage?: keyof NonNullable<IVideo['captions']>
     loop?: boolean
     gif: IGif
     width: number
@@ -223,7 +223,7 @@ const Video = ({
             }
         }
     }, [_onPlaying, _onPaused, _onError, _onTimeUpdate, _onCanPlay, _onEnded, _onWaiting, _onEndFullscreen])
-    const captionSrc = gif.video?.captions[ccLanguage]?.vtt
+    const captionSrc = gif.video?.captions?.[ccLanguage]?.vtt
     return media?.url ? (
         <video
             crossOrigin="anonymous"

--- a/packages/react-components/stories/video.stories.tsx
+++ b/packages/react-components/stories/video.stories.tsx
@@ -12,8 +12,8 @@ const eventAction = (event: string) => {
     action(`Video ${event}`)()
 }
 
-type Props = { id: string; width: number; height?: number; muted: boolean }
-const VideoDemo = ({ id, width, height, muted }: Props) => {
+type Props = { id: string; width: number; height?: number; muted: boolean; ccEnabled?: boolean }
+const VideoDemo = ({ id, width, height, muted, ccEnabled }: Props) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = useCallback(async () => {
@@ -38,6 +38,7 @@ const VideoDemo = ({ id, width, height, muted }: Props) => {
             onQuartile={(qt) => eventAction(`on quartile ${qt}`)}
             onMuted={() => eventAction('on muted')}
             onWaiting={(count: number) => eventAction(`on waiting: ${count}`)}
+            ccEnabled={ccEnabled}
             // onTimeUpdate={(t) => console.log(t)}
         />
     ) : null
@@ -55,6 +56,19 @@ export const Video = () => (
         height={number('height', 0)}
         muted={boolean('muted', false)}
     />
+)
+
+export const VideoCaptionsBeta = () => (
+    <>
+        <h3 style={{ color: 'white' }}>Beta Feature</h3>
+        <VideoDemo
+            id={text('id', 'D068R9Ziv1iCjezKzG')}
+            width={number('width', 300)}
+            height={number('height', 0)}
+            muted={boolean('muted', true)}
+            ccEnabled={boolean('ccEnabled', true)}
+        />
+    </>
 )
 
 export const VideoUserMuted = () => (

--- a/packages/types/src/video.ts
+++ b/packages/types/src/video.ts
@@ -20,6 +20,6 @@ export default interface IVideo {
     dash_manifest_url: string
     hls_manifest_url: string
     previews: IImages
-    captions: Partial<Record<Language, ICaption>>
+    captions?: Partial<Record<Language, ICaption>>
     native: Language
 }

--- a/packages/types/src/video.ts
+++ b/packages/types/src/video.ts
@@ -8,11 +8,18 @@ export interface IVideoAssets {
     '1080p': IURLAsset
     '4k': IURLAsset
 }
-
+// TODO add more languages
+export type Language = 'en' | 'fr' | 'sp' | 'it' | 'de'
+export interface ICaption {
+    srt: string
+    vtt: string
+}
 export default interface IVideo {
     assets: IVideoAssets
     description: string
     dash_manifest_url: string
     hls_manifest_url: string
     previews: IImages
+    captions: Partial<Record<Language, ICaption>>
+    native: Language
 }


### PR DESCRIPTION

- types - Add `captions` property to the `video` data 
- react-components - if `ccEnabled` grab the captions data and add a `track` node from `captions` based on the `ccLanguage` value which defaults to `en`