### PR TITLE
feat(carousel): add a gifWidth option for fixed width carousel items

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -94,6 +94,7 @@ _renderCarousel options_
 | property                                | type                                     | default   | description                                                                                           |
 | --------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
 | gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                                               |
+| gifWidth                               | `number`                                 | undefined | The width of the gifs and the carousel (you may want to set Gif.imgClassName to have object-fit: cover to avoid stretching)                                                              |
 | fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                              |
 | gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
 | noResultsMessage                        | `string \| element`                      | undefined | Customise the "No results" message                                                                    |

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -38,6 +38,7 @@ type Props = {
     className?: string
     user: Partial<IUser>
     gifHeight: number
+    gifWidth?: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
@@ -107,6 +108,7 @@ class Carousel extends Component<Props, State> {
             onGifVisible,
             onGifRightClick,
             gifHeight,
+            gifWidth,
             gutter,
             className = Carousel.className,
             onGifClick,
@@ -134,14 +136,14 @@ class Carousel extends Component<Props, State> {
             <PingbackContextManager attributes={{ layout_type: 'CAROUSEL' }}>
                 <div class={containerCss}>
                     {gifs.map((gif) => {
-                        const gifWidth = getGifWidth(gif, gifHeight)
                         return (
                             <Gif
                                 className={gifCss}
                                 gif={gif}
                                 key={gif.id}
                                 tabIndex={tabIndex}
-                                width={gifWidth}
+                                width={gifWidth || getGifWidth(gif, gifHeight)}
+                                height={gifHeight}
                                 onGifClick={onGifClick}
                                 onGifHover={onGifHover}
                                 onGifSeen={onGifSeen}

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -76,6 +76,7 @@ See this [codesandbox](https://codesandbox.io/s/giphy-web-sdk-ssr-with-nextjs-ir
 | _prop_                                  | _type_                                   | _default_ | _description_                                                                                           |
 | --------------------------------------- | ---------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
 | gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                                                 |
+| gifWidth                               | `number`                                 | undefined | The width of the gifs and the carousel (you may want to set Gif.imgClassName to have object-fit: cover to avoid stretching) 
 | fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                                |
 | gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                      |
 | borderRadius                            | `number`                                 | 4         | a border radius applied to Gif Components making the corners rounded                                    |

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -50,6 +50,7 @@ type Props = {
     className?: string
     user: Partial<IUser>
     gifHeight: number
+    gifWidth?: number
     gutter: number
     fetchGifs: (offset: number) => Promise<GifsResult>
     onGifsFetched?: (gifs: IGif[]) => void
@@ -126,6 +127,7 @@ class Carousel extends PureComponent<Props, State> {
             onGifVisible,
             onGifRightClick,
             gifHeight,
+            gifWidth,
             gutter,
             className = Carousel.className,
             onGifSeen,
@@ -147,13 +149,13 @@ class Carousel extends PureComponent<Props, State> {
             <PingbackContextManager attributes={{ layout_type: 'CAROUSEL' }}>
                 <Container className={className}>
                     {gifs.map((gif) => {
-                        const gifWidth = getGifWidth(gif, gifHeight)
                         return (
                             <Gif
                                 gif={gif}
                                 key={gif.id}
                                 tabIndex={tabIndex}
-                                width={gifWidth}
+                                width={gifWidth || getGifWidth(gif, gifHeight)}
+                                height={gifHeight}
                                 onGifClick={onGifClick}
                                 onGifSeen={onGifSeen}
                                 onGifVisible={onGifVisible}

--- a/packages/react-components/stories/carousel.stories.tsx
+++ b/packages/react-components/stories/carousel.stories.tsx
@@ -38,6 +38,7 @@ export const SearchExample = () => {
             <CarouselComponent
                 key={term}
                 gifHeight={number('gif height', 200)}
+                gifWidth={number('gif width', undefined)}
                 backgroundColor={isPercy() ? 'white' : undefined}
                 gutter={6}
                 fetchGifs={fetchGifs}


### PR DESCRIPTION
Carousels can now have a fixed width look by setting a `gifWidth` property on the `Carousel` component:
<img width="711" alt="Screen Shot 2022-02-23 at 11 30 29 AM" src="https://user-images.githubusercontent.com/448767/155393809-d1a4fc66-8199-408a-b40b-3ddf5960d06d.png">
Without fixed width:
<img width="680" alt="Screen Shot 2022-02-23 at 11 31 44 AM" src="https://user-images.githubusercontent.com/448767/155394002-ea6ccfae-936e-4e61-a406-cb2fc63729ca.png">

