### PR TITLE
fix(Grid): can't perform a React state update on an unmounted component

### DIFF
--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -104,7 +104,9 @@ class Grid extends PureComponent<Props, State> {
             let gifs
             try {
                 gifs = await this.paginator()
+                if (this.unmounted) return
             } catch (error) {
+                if (this.unmounted) return
                 this.setState({ isFetching: false, isError: true })
                 const { onGifsFetchError } = this.props
                 if (onGifsFetchError) onGifsFetchError(error)


### PR DESCRIPTION
fix(Grid): can't perform a React state update on an unmounted component

re #277