### PR TITLE
Fix - WebP Loading Bug

### DIFF
--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -99,7 +99,7 @@ const Gif = ({
     // hovered is for the gif overlay
     const [isHovered, setHovered] = useState(false)
     // only show the gif if it's on the screen
-    const [showGif, setShowGif] = useState(false)
+    const [shouldShowMedia, setShouldShowMedia] = useState(false)
     // the background color shouldn't change unless it comes from a prop or we have a sticker
     const defaultBgColor = useRef(getColor())
     // the a tag the media is rendered into
@@ -183,7 +183,7 @@ const Gif = ({
         showGifObserver.current = new IntersectionObserver(([entry]: IntersectionObserverEntry[]) => {
             const { isIntersecting } = entry
             // show the gif if the container is on the screen
-            setShowGif(isIntersecting)
+            setShouldShowMedia(isIntersecting)
             // remove the fullGifObserver if we go off the screen
             // we may have already disconnected if the hasFiredSeen happened
             if (!isIntersecting && fullGifObserver.current) {
@@ -230,18 +230,18 @@ const Gif = ({
         >
             <div style={{ width, height, position: 'relative' }} ref={container}>
                 <picture>
-                    <source type="image/webp" srcSet={showGif ? rendition.webp : placeholder} />
+                    <source type="image/webp" srcSet={shouldShowMedia ? rendition.webp : placeholder} />
                     <img
                         className={[Gif.imgClassName, loadedClassname].join(' ')}
-                        src={showGif ? rendition.url : placeholder}
+                        src={shouldShowMedia ? rendition.url : placeholder}
                         style={{ background }}
                         width={width}
                         height={height}
                         alt={getAltText(gif)}
-                        onLoad={showGif ? onImageLoad : () => {}}
+                        onLoad={shouldShowMedia ? onImageLoad : () => {}}
                     />
                 </picture>
-                {showGif ? (
+                {shouldShowMedia ? (
                     <div>{!hideAttribution && <AttributionOverlay gif={gif} isHovered={isHovered} />}</div>
                 ) : null}
             </div>

--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -230,7 +230,7 @@ const Gif = ({
         >
             <div style={{ width, height, position: 'relative' }} ref={container}>
                 <picture>
-                    <source type="image/webp" srcSet={rendition.webp} />
+                    <source type="image/webp" srcSet={showGif ? rendition.webp : placeholder} />
                     <img
                         className={[Gif.imgClassName, loadedClassname].join(' ')}
                         src={showGif ? rendition.url : placeholder}

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -122,7 +122,7 @@ class Grid extends Component<Props, State> {
             } catch (error) {
                 this.setState({ isFetching: false, isError: true })
                 const { onGifsFetchError } = this.props
-                if (onGifsFetchError) onGifsFetchError(error)
+                if (onGifsFetchError) onGifsFetchError(error as Error)
             }
             if (gifs) {
                 if (existingGifs.length === gifs.length) {

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -251,7 +251,7 @@ const Gif = ({
         >
             <div style={{ width, height, position: 'relative' }} ref={container}>
                 <picture>
-                    <source type="image/webp" srcSet={rendition.webp} />
+                    <source type="image/webp" srcSet={showGif ? rendition.webp : placeholder} />
                     <img
                         ref={image}
                         suppressHydrationWarning

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -106,7 +106,7 @@ const Gif = ({
     const [isHovered, setHovered] = useState(false)
     // only show the gif if it's on the screen
     // if we can't use the dom (SSR), then we show the gif by default
-    const [showGif, setShowGif] = useState(!canUseDOM)
+    const [shouldShowMedia, setShouldShowMedia] = useState(!canUseDOM)
     // classname to target animations on image load
     const [loadedClassname, setLoadedClassName] = useState('')
     // the background color shouldn't change unless it comes from a prop or we have a sticker
@@ -209,7 +209,7 @@ const Gif = ({
         showGifObserver.current = new IntersectionObserver(([entry]: IntersectionObserverEntry[]) => {
             const { isIntersecting } = entry
             // show the gif if the container is on the screen
-            setShowGif(isIntersecting)
+            setShouldShowMedia(isIntersecting)
             // remove the fullGifObserver if we go off the screen
             // we may have already disconnected if the hasFiredSeen happened
             if (!isIntersecting && fullGifObserver.current) {
@@ -251,20 +251,22 @@ const Gif = ({
         >
             <div style={{ width, height, position: 'relative' }} ref={container}>
                 <picture>
-                    <source type="image/webp" srcSet={showGif ? rendition.webp : placeholder} />
+                    <source type="image/webp" srcSet={shouldShowMedia ? rendition.webp : placeholder} />
                     <img
                         ref={image}
                         suppressHydrationWarning
                         className={[Gif.imgClassName, loadedClassname].join(' ')}
-                        src={showGif ? rendition.url : placeholder}
+                        src={shouldShowMedia ? rendition.url : placeholder}
                         style={{ background }}
                         width={width}
                         height={height}
                         alt={getAltText(gif)}
-                        onLoad={showGif ? onImageLoad : () => {}}
+                        onLoad={shouldShowMedia ? onImageLoad : () => {}}
                     />
                 </picture>
-                {showGif ? Overlay && <Overlay gif={gif} isHovered={isHovered} width={width} height={height} /> : null}
+                {shouldShowMedia
+                    ? Overlay && <Overlay gif={gif} isHovered={isHovered} width={width} height={height} />
+                    : null}
             </div>
         </Container>
     )

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -109,7 +109,7 @@ class Grid extends PureComponent<Props, State> {
                 if (this.unmounted) return
                 this.setState({ isFetching: false, isError: true })
                 const { onGifsFetchError } = this.props
-                if (onGifsFetchError) onGifsFetchError(error)
+                if (onGifsFetchError) onGifsFetchError(error as Error)
             }
             if (gifs) {
                 // if we've just fetched and we don't have


### PR DESCRIPTION
Our Gif component only loaded a `.gif` when on the screen using intersection observer, however that logic was missing from `.webp`, which really is all we load. Bummer of a bug here, surprised we never caught it until now