### PR TITLE
add env variable to stop fonts from loading

### DIFF
--- a/packages/brand/README.md
+++ b/packages/brand/README.md
@@ -1,3 +1,5 @@
 # @giphy/js-brand
 
-Colors, fonts - WIP
+Colors, fonts
+
+To stop fonts from loading set the environment variable `GIPHY_SDK_NO_FONTS=true`, this is not recommended as it could cause inconsistencies in the ui components 

--- a/packages/brand/src/typography.ts
+++ b/packages/brand/src/typography.ts
@@ -1,7 +1,6 @@
 import { css, cx, injectGlobal } from 'emotion'
 
-// eslint-disable-next-line
-injectGlobal`
+export const addFonts = () => injectGlobal`
 @font-face {
     font-family: 'interface';
     font-style: normal;
@@ -43,6 +42,9 @@ injectGlobal`
     src:  url('https://s3.amazonaws.com/giphyscripts/react-giphy-brand/fonts/ss-social.woff') format('woff');
 }
 `
+if (!process.env.GIPHY_SDK_NO_FONTS) {
+    addFonts()
+}
 
 export const fontFamily = {
     title: "'nexablack', sans-serif",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -205,3 +205,5 @@ If a GIF has an associated user, an overlay with their avatar and display name w
 ```
 
 ```
+
+To stop fonts from loading set the environment variable `GIPHY_SDK_NO_FONTS=true`, this is not recommended as it could cause inconsistencies in the ui components 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -324,3 +324,6 @@ If you want to prefetch network requests before the loader appears in Grids and 
 | onGifClick      | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is clicked                                   |
 | onGifRightClick | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the gif is right clicked                             |
 | onGifKeyPress   | `(gif: IGif, e: SyntheticEvent<HTMLElement, Event>) => void`         | fired when the a key is pressed on the gif                      |
+
+
+To stop fonts from loading set the environment variable `GIPHY_SDK_NO_FONTS=true`, this is not recommended as it could cause inconsistencies in the ui components 


### PR DESCRIPTION
For #291

Our components are designed to work with specific fonts, but you can stop the fonts from loading by using an environment variable `GIPHY_SDK_NO_FONTS=true`. 

