### PR TITLE
chore: cover the main components with basic tests

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -100,7 +100,7 @@ module.exports = {
             severity: 'error',
             from: {},
             to: {
-                pathNot: 'react',
+                pathNot: ['react', 'cypress/types/*'],
                 couldNotResolve: true,
             },
         },

--- a/.eslintrc
+++ b/.eslintrc
@@ -64,6 +64,14 @@
         ],
         "space-before-function-paren": ["error", { "anonymous": "never", "named": "never", "asyncArrow": "always" }]
     },
+    "overrides": [
+        {
+            "files": ["**/cypress/**/*.ts", "**/cypress/**/*.tsx"],
+            "rules": {
+                "@typescript-eslint/no-unused-expressions": 0
+            }
+        }
+    ],
     "settings": {
         "import/parser": {
             "@typescript-eslint/parser": [".ts", ".tsx"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ script:
   - yarn run dependency-cruiser
   - yarn run lint
   - yarn test
-  - yarn run snapshot
+  # All Percy snapshots except SearchBar have been moved to Cypress, to avoid confusion disable the old "snapshot" command.
+  # When the Cypress setuisbe verified, this command might be removed.
+  # - yarn run snapshot
   - yarn run cy:run --record --key ${CYPRESS_RECORD_KEY}
   # after all tests finish running we need
   # to kill all background jobs (like "npm start &")

--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -1,4 +1,4 @@
-const isTestsRunner = process.env.NODE_ENV === 'PERCY' || process.env.NODE_ENV === 'cypress' // isPercy package doesn't work here
+const isTestsRunner = process.env.NODE_ENV === 'PERCY' || !!window.Cypress // is-tests-runner package doesn't work here
 
 module.exports = {
     stories: ['../**/*.stories.tsx'],

--- a/packages/react-components/.storybook/main.js
+++ b/packages/react-components/.storybook/main.js
@@ -1,4 +1,4 @@
-const isTestsRunner = process.env.NODE_ENV === 'PERCY' || !!window.Cypress // is-tests-runner package doesn't work here
+const isTestsRunner = process.env.NODE_ENV === 'PERCY' || (typeof window !== 'undefined' && !!window.Cypress) // is-tests-runner package doesn't work here
 
 module.exports = {
     stories: ['../**/*.stories.tsx'],

--- a/packages/react-components/cypress.config.ts
+++ b/packages/react-components/cypress.config.ts
@@ -2,12 +2,10 @@ import { defineConfig } from 'cypress'
 
 export default defineConfig({
     requestTimeout: 30000,
+    defaultCommandTimeout: 10000,
     video: false,
-    viewportWidth: 1100,
+    viewportWidth: 1080,
     projectId: 'zse12i',
-    env: {
-        NODE_ENV: 'cypress',
-    },
     retries: {
         runMode: 2,
         openMode: 0,

--- a/packages/react-components/cypress/.eslintrc
+++ b/packages/react-components/cypress/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "extends": ["../.eslintrc"],
+    "rules": {
+        "@typescript-eslint/no-unused-expressions": ["off"]
+    }
+}

--- a/packages/react-components/cypress/.eslintrc
+++ b/packages/react-components/cypress/.eslintrc
@@ -1,6 +1,0 @@
-{
-    "extends": ["../.eslintrc"],
-    "rules": {
-        "@typescript-eslint/no-unused-expressions": ["off"]
-    }
-}

--- a/packages/react-components/cypress/stories/attribution.spec.tsx
+++ b/packages/react-components/cypress/stories/attribution.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { SinonStub } from 'cypress/types/sinon'
 import { composeStories } from '@storybook/testing-react'
 
+import { Gif } from '../../src'
 import * as stories from '../../stories/attribution.stories'
 
 const { Attribution } = composeStories(stories)
@@ -13,7 +14,7 @@ function getAttributionRoot() {
 }
 
 function getAttributionGifs() {
-    return cy.get(`[data-cy-root] [data-gph-gif="${GIF_ID}"]`)
+    return cy.get(`[data-cy-root] .${Gif.className}[data-giphy-id="${GIF_ID}"]`)
 }
 
 function checkAttributionIsVisible() {

--- a/packages/react-components/cypress/stories/attribution.spec.tsx
+++ b/packages/react-components/cypress/stories/attribution.spec.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+import { SinonStub } from 'cypress/types/sinon'
+import { composeStories } from '@storybook/testing-react'
+
+import * as stories from '../../stories/attribution.stories'
+
+const { Attribution } = composeStories(stories)
+
+const GIF_ID = 'l0HlyLQsbvhciAuKA'
+
+function getAttributionRoot() {
+    return cy.get('[data-cy-root] .giphy-attribution')
+}
+
+function getAttributionGifs() {
+    return cy.get(`[data-cy-root] [data-gph-gif="${GIF_ID}"]`)
+}
+
+function checkAttributionIsVisible() {
+    getAttributionRoot().should('be.visible')
+    getAttributionGifs().then((gifs) => {
+        expect(gifs.length).eq(2)
+        cy.wrap(gifs).should('be.visible')
+    })
+}
+
+describe('Attribution', () => {
+    let onClick: SinonStub
+    beforeEach(() => {
+        cy.stub(window, 'open')
+        onClick = cy.stub().as('onClick')
+    })
+
+    it('Default', () => {
+        cy.mount(<Attribution />)
+        checkAttributionIsVisible()
+        cy.percySnapshot('Attribution / Default')
+        getAttributionRoot()
+            .click()
+            .then(() => {
+                expect(window.open).be.calledWithMatch('https://giphy.com/haydiroket/', '_blank')
+                expect(onClick).be.not.be.called
+            })
+    })
+
+    it('Custom OnClick Handler', () => {
+        cy.mount(<Attribution onClick={onClick} />)
+        checkAttributionIsVisible()
+        cy.percySnapshot('Attribution / Custom OnClick Handler')
+        getAttributionRoot()
+            .click()
+            .then(() => {
+                expect(window.open).not.be.called
+                expect(onClick).be.calledWithMatch({ id: GIF_ID })
+            })
+    })
+})

--- a/packages/react-components/cypress/stories/attribution.spec.tsx
+++ b/packages/react-components/cypress/stories/attribution.spec.tsx
@@ -18,10 +18,8 @@ function getAttributionGifs() {
 
 function checkAttributionIsVisible() {
     getAttributionRoot().should('be.visible')
-    getAttributionGifs().then((gifs) => {
-        expect(gifs.length).eq(2)
-        cy.wrap(gifs).should('be.visible')
-    })
+    getAttributionGifs().its('length').should('eq', 2)
+    getAttributionGifs().should('be.visible')
 }
 
 describe('Attribution', () => {

--- a/packages/react-components/cypress/stories/carousel.spec.tsx
+++ b/packages/react-components/cypress/stories/carousel.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import { composeStories } from '@storybook/testing-react'
+import { SinonStub } from 'cypress/types/sinon'
+
+import * as stories from '../../stories/carousel.stories'
+import {
+    checkGifSeen,
+    checkGifIsVisible,
+    checkGifKeyboardEvents,
+    checkGifMouseEvents,
+    GifTestUtilsContext,
+    resetGifEventsHistory,
+    setupGifTestUtils,
+} from '../utils/gif-test-utils'
+
+const GIFS_COUNT = 5
+
+const { SearchExample } = composeStories(stories)
+
+function getCarouselRoot() {
+    return cy.get('.cy-carousel')
+}
+
+function getCarouselGifs() {
+    return getCarouselRoot().children('[data-gph-gif]')
+}
+
+function forEachGif(fn: (gifId: string, index: number) => void) {
+    getCarouselGifs().each((gif, idx) =>
+        cy
+            .wrap(gif)
+            .invoke('attr', 'data-gph-gif')
+            .then((gifId) => fn(gifId as string, idx))
+    )
+}
+
+describe('Carousel', () => {
+    let gifUtilsCtx: GifTestUtilsContext
+    let onGifsFetched: SinonStub
+    before(() => {
+        gifUtilsCtx = setupGifTestUtils('')
+        onGifsFetched = cy.stub().as('onGifsFetched')
+    })
+
+    it('SearchExample', () => {
+        cy.mount(<SearchExample className="cy-carousel" noLink onGifsFetched={onGifsFetched} {...gifUtilsCtx.events} />)
+
+        cy.wrap(onGifsFetched).should('be.called')
+        getCarouselGifs().should('be.visible').its('length').should('eq', GIFS_COUNT)
+        cy.percySnapshot('Carousel / SearchExample')
+
+        forEachGif((gifId, idx) => {
+            gifUtilsCtx.gifId = gifId as string
+            checkGifIsVisible(gifUtilsCtx)
+            // Check only the first and last element to avoid test drift at different viewport sizes
+            if (idx === 0) {
+                checkGifSeen(gifUtilsCtx)
+            } else if (idx === GIFS_COUNT - 1) {
+                expect(gifUtilsCtx.events.onGifSeen).not.be.calledWithMatch({ id: gifId })
+            }
+        })
+
+        forEachGif((gifId) => {
+            gifUtilsCtx.gifId = gifId as string
+            resetGifEventsHistory(gifUtilsCtx)
+            checkGifMouseEvents(gifUtilsCtx)
+            checkGifKeyboardEvents(gifUtilsCtx)
+        })
+    })
+})

--- a/packages/react-components/cypress/stories/carousel.spec.tsx
+++ b/packages/react-components/cypress/stories/carousel.spec.tsx
@@ -22,14 +22,14 @@ function getCarouselRoot() {
 }
 
 function getCarouselGifs() {
-    return getCarouselRoot().children('[data-gph-gif]')
+    return getCarouselRoot().children('[data-giphy-id]')
 }
 
 function forEachGif(fn: (gifId: string, index: number) => void) {
     getCarouselGifs().each((gif, idx) =>
         cy
             .wrap(gif)
-            .invoke('attr', 'data-gph-gif')
+            .invoke('attr', 'data-giphy-id')
             .then((gifId) => fn(gifId as string, idx))
     )
 }

--- a/packages/react-components/cypress/stories/gif.spec.tsx
+++ b/packages/react-components/cypress/stories/gif.spec.tsx
@@ -1,25 +1,43 @@
 import * as React from 'react'
 import { composeStories } from '@storybook/testing-react'
-import { mount } from '@cypress/react'
 
 import * as stories from '../../stories/gif.stories'
+import { storiesCompositionToList } from '../utils/storybook'
+import {
+    setupGifTestUtils,
+    GifTestUtilsContext,
+    checkGifSeen,
+    checkGifMouseEvents,
+    checkGifKeyboardEvents,
+    checkGifIsVisible,
+} from '../utils/gif-test-utils'
 
-const { Gif } = composeStories(stories)
+const storiesGifIds = {
+    Gif: 'ZEU9ryYGZzttn0Cva7',
+    GifWithVideoOverlay: 'D068R9Ziv1iCjezKzG',
+    GifWithVideoOverlayFillVideo: '3BNRWBatePBETD7Bfg',
+    GifNoBorderRadius: 'ZEU9ryYGZzttn0Cva7',
+    Sticker: 'l1J9FvenuBnI4GTeg',
+    CustomPingbackGif: 'ZEU9ryYGZzttn0Cva7',
+} as const
 
-describe('Gif Stories', () => {
-    beforeEach(() => {
-        cy.intercept('GET', 'https://api.giphy.com/v1/gifs/*').as('gif-by-id')
-    })
+const composedStories = storiesCompositionToList(composeStories(stories))
 
-    describe('Default Gif', () => {
-        it('Should render a specified gif', () => {
-            mount(<Gif />)
+describe('Gif', () => {
+    composedStories.forEach((story) => {
+        let gifTestUtilsCtx: GifTestUtilsContext
 
-            cy.wait('@gif-by-id')
-            cy.get('img.giphy-img-loaded').should('be.visible')
+        before(() => {
+            gifTestUtilsCtx = setupGifTestUtils(storiesGifIds[story.key])
+        })
 
-            // IMG is loaded, so Percy can take the correct snapshot
-            cy.percySnapshot('Default Gif')
+        it(story.key, () => {
+            const options = { takeSnapshots: true, snapshotNamePrefix: `Stories / Gif / ${story.key}` }
+            cy.mount(<story.Component {...gifTestUtilsCtx.events} />)
+            checkGifIsVisible(gifTestUtilsCtx)
+            checkGifSeen(gifTestUtilsCtx, options)
+            checkGifMouseEvents(gifTestUtilsCtx, options)
+            checkGifKeyboardEvents(gifTestUtilsCtx, options)
         })
     })
 })

--- a/packages/react-components/cypress/stories/grid.spec.tsx
+++ b/packages/react-components/cypress/stories/grid.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { composeStories, composeStory } from '@storybook/testing-react'
 import { SinonStub } from 'cypress/types/sinon'
 
+import { Grid } from '../../src'
 import * as stories from '../../stories/grid.stories'
 import { storiesCompositionToList } from '../utils/storybook'
 import {
@@ -22,18 +23,18 @@ const composedStories = storiesCompositionToList(composeStories(stories)).filter
 )
 
 function getGridRoot() {
-    return cy.get('.giphy-grid')
+    return cy.get(`.${Grid.className}`)
 }
 
 function getGridGifs() {
-    return getGridRoot().get('[data-gph-gif]')
+    return getGridRoot().get('[data-giphy-id]')
 }
 
 function forEachGif(fn: (gifId: string, index: number) => void) {
     getGridGifs().each((gif, idx) =>
         cy
             .wrap(gif)
-            .invoke('attr', 'data-gph-gif')
+            .invoke('attr', 'data-giphy-id')
             .then((gifId) => fn(gifId as string, idx))
     )
 }

--- a/packages/react-components/cypress/stories/grid.spec.tsx
+++ b/packages/react-components/cypress/stories/grid.spec.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import { composeStories, composeStory } from '@storybook/testing-react'
+import { SinonStub } from 'cypress/types/sinon'
+
+import * as stories from '../../stories/grid.stories'
+import { storiesCompositionToList } from '../utils/storybook'
+import {
+    checkGifSeen,
+    checkGifIsVisible,
+    checkGifKeyboardEvents,
+    checkGifMouseEvents,
+    GifTestUtilsContext,
+    resetGifEventsHistory,
+    setupGifTestUtils,
+} from '../utils/gif-test-utils'
+
+const GIFS_COUNT = 5
+
+const GridAPIError = composeStory(stories.GridAPIError, {})
+const composedStories = storiesCompositionToList(composeStories(stories)).filter(
+    (story) => story.key !== 'GridAPIError'
+)
+
+function getGridRoot() {
+    return cy.get('.giphy-grid')
+}
+
+function getGridGifs() {
+    return getGridRoot().get('[data-gph-gif]')
+}
+
+function forEachGif(fn: (gifId: string, index: number) => void) {
+    getGridGifs().each((gif, idx) =>
+        cy
+            .wrap(gif)
+            .invoke('attr', 'data-gph-gif')
+            .then((gifId) => fn(gifId as string, idx))
+    )
+}
+
+describe('Grid', () => {
+    composedStories.forEach((story) => {
+        let gifUtilsCtx: GifTestUtilsContext
+        let onGifsFetched: SinonStub
+
+        before(() => {
+            gifUtilsCtx = setupGifTestUtils('')
+            onGifsFetched = cy.stub().as('onGifsFetched')
+        })
+
+        it(story.key, () => {
+            cy.mount(<story.Component noLink onGifsFetched={onGifsFetched} {...gifUtilsCtx.events} />)
+
+            cy.wrap(onGifsFetched).should('be.called')
+            getGridGifs().should('be.visible').its('length').should('eq', GIFS_COUNT)
+            cy.percySnapshot(`Grid / ${story.key}`)
+
+            forEachGif((gifId, idx) => {
+                gifUtilsCtx.gifId = gifId as string
+                checkGifIsVisible(gifUtilsCtx)
+                // Check only the first to avoid test drift at different viewport sizes
+                if (idx === 0) {
+                    checkGifSeen(gifUtilsCtx)
+                }
+            })
+
+            forEachGif((gifId) => {
+                gifUtilsCtx.gifId = gifId as string
+                resetGifEventsHistory(gifUtilsCtx)
+                checkGifMouseEvents(gifUtilsCtx)
+                checkGifKeyboardEvents(gifUtilsCtx)
+            })
+        })
+    })
+
+    it('GridAPIError', () => {
+        const onGifsFetched = cy.stub().as('onGifsFetched')
+        cy.mount(<GridAPIError onGifsFetched={onGifsFetched} />)
+
+        cy.wait(1000)
+        getGridRoot().should('be.visible')
+        getGridGifs().should('not.exist')
+        cy.wrap(onGifsFetched).should('not.be.called')
+        cy.percySnapshot('Grid / GridAPIError')
+    })
+})

--- a/packages/react-components/cypress/stories/loader.spec.tsx
+++ b/packages/react-components/cypress/stories/loader.spec.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+import { composeStories } from '@storybook/testing-react'
+
+import * as stories from '../../stories/loader.stories'
+
+const { DotsLoader } = composeStories(stories)
+
+describe('Loader', () => {
+    it('DotsLoader', () => {
+        cy.mount(<DotsLoader className="cy-loader" />)
+        cy.get('.cy-loader').should('be.visible')
+        cy.percySnapshot('Loader / DotsLoader')
+    })
+})

--- a/packages/react-components/cypress/stories/video-player.spec.tsx
+++ b/packages/react-components/cypress/stories/video-player.spec.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import { composeStories } from '@storybook/testing-react'
+
+import * as stories from '../../stories/video-player.stories'
+import { storiesCompositionToList } from '../utils/storybook'
+import {
+    setupVideoTestUtils,
+    VideoTestUtilsContext,
+    checkVideoIsVisible,
+    checkVideoEvents,
+} from '../utils/video-test-utils'
+
+const GIF_ID = 'WtUBmrAK1Yda649Ayr'
+
+const composedStories = storiesCompositionToList(composeStories(stories))
+
+describe('Video Player', () => {
+    composedStories.forEach((story) => {
+        let videoTestUtilsCtx: VideoTestUtilsContext
+
+        before(() => {
+            videoTestUtilsCtx = setupVideoTestUtils(GIF_ID, { loop: true })
+        })
+
+        it(story.key, () => {
+            const snapshotNamePrefix = `Stories / Video Player / ${story.key}`
+            cy.mount(<story.Component {...videoTestUtilsCtx.events} />)
+
+            checkVideoIsVisible(videoTestUtilsCtx, { takeSnapshots: true, snapshotNamePrefix })
+            // Check events only for one story to save resources on duplicate tests
+            if (story.key === 'VideoWithControls') {
+                checkVideoEvents(videoTestUtilsCtx)
+            }
+        })
+    })
+})

--- a/packages/react-components/cypress/stories/video.spec.tsx
+++ b/packages/react-components/cypress/stories/video.spec.tsx
@@ -46,6 +46,7 @@ describe('Video', () => {
     it('VideoNoContent', () => {
         const gifId = storiesGifIds.VideoNoContent
         cy.mount(<VideoNoContent />)
+        cy.wait(1000)
         getVideoElement(gifId).should('not.exist')
         cy.percySnapshot('Video - VideoNoContent')
     })

--- a/packages/react-components/cypress/stories/video.spec.tsx
+++ b/packages/react-components/cypress/stories/video.spec.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import { composeStories, composeStory } from '@storybook/testing-react'
+
+import * as stories from '../../stories/video.stories'
+import { storiesCompositionToList } from '../utils/storybook'
+import {
+    setupVideoTestUtils,
+    VideoTestUtilsContext,
+    checkVideoIsVisible,
+    getVideoElement,
+    checkVideoEvents,
+} from '../utils/video-test-utils'
+
+const storiesGifIds = {
+    Video: 'D068R9Ziv1iCjezKzG',
+    VideoCaptionsBeta: 'D068R9Ziv1iCjezKzG',
+    VideoUserMuted: 'obhOJFSwuTRN7VDY55',
+    VideoNoContent: 'ZEU9ryYGZzttn0Cva7',
+} as const
+
+const VideoNoContent = composeStory(stories.VideoNoContent, {})
+const composedStories = storiesCompositionToList(composeStories(stories)).filter(
+    (story) => story.key !== 'VideoNoContent'
+)
+
+describe('Video', () => {
+    composedStories.forEach((story) => {
+        let videoTestUtilsCtx: VideoTestUtilsContext
+
+        before(() => {
+            videoTestUtilsCtx = setupVideoTestUtils(storiesGifIds[story.key], { loop: true })
+        })
+
+        it(story.key, () => {
+            const snapshotNamePrefix = `Video - ${story.key}`
+            cy.mount(<story.Component {...videoTestUtilsCtx.events} />)
+
+            checkVideoIsVisible(videoTestUtilsCtx, { takeSnapshots: true, snapshotNamePrefix })
+            // Check events only for one story to save resources on duplicate tests
+            if (story.key === 'Video') {
+                checkVideoEvents(videoTestUtilsCtx)
+            }
+        })
+    })
+
+    it('VideoNoContent', () => {
+        const gifId = storiesGifIds.VideoNoContent
+        cy.mount(<VideoNoContent />)
+        getVideoElement(gifId).should('not.exist')
+        cy.percySnapshot('Video - VideoNoContent')
+    })
+})

--- a/packages/react-components/cypress/support/commands.ts
+++ b/packages/react-components/cypress/support/commands.ts
@@ -1,0 +1,47 @@
+import { mount } from '@cypress/react'
+
+import { resetKnobs } from '../utils/storybook'
+
+function stopVideo(elements: JQuery<HTMLVideoElement> | void) {
+    const source = elements ? cy.wrap(elements) : cy.get('video')
+    source
+        .then((videos) =>
+            Promise.all(
+                videos.toArray().map(async (el: HTMLVideoElement) => {
+                    // Wait until all a video is ready to avoid "play-request-was-interrupted-by-a-call-to-pause" error
+                    await el.play()
+                    el.autoplay = false
+                    el.currentTime = 0
+
+                    return new Promise((resolve) => {
+                        function pauseHandler() {
+                            el.removeEventListener('pause', pauseHandler)
+                            resolve(null)
+                        }
+
+                        el.addEventListener('pause', pauseHandler)
+                        el.pause()
+                    })
+                })
+            )
+        )
+        .as('stopVideo')
+}
+
+// Augment the Cypress namespace to include type definitions for
+// your custom command.
+// Alternatively, can be defined in cypress/support/component.d.ts
+// with a <reference path="./component" /> at the top of your spec.
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            mount: typeof mount
+            resetKnobs: typeof resetKnobs
+            stopVideo: () => void
+        }
+    }
+}
+
+Cypress.Commands.add('mount', mount)
+Cypress.Commands.add('resetKnobs', resetKnobs)
+Cypress.Commands.add('stopVideo', { prevSubject: ['optional'] }, stopVideo)

--- a/packages/react-components/cypress/support/component-index.html
+++ b/packages/react-components/cypress/support/component-index.html
@@ -5,6 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>Components App</title>
+
+    <style>
+      .hide-in-percy {
+        visibility: hidden;
+      }
+    </style>
   </head>
   <body>
     <div data-cy-root></div>

--- a/packages/react-components/cypress/support/component.ts
+++ b/packages/react-components/cypress/support/component.ts
@@ -18,24 +18,8 @@ import '@percy/cypress'
 // Import commands.js using ES2015 syntax:
 import './commands'
 
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
-import { mount } from 'cypress/react'
-
-// Augment the Cypress namespace to include type definitions for
-// your custom command.
-// Alternatively, can be defined in cypress/support/component.d.ts
-// with a <reference path="./component" /> at the top of your spec.
-declare global {
-    namespace Cypress {
-        interface Chainable {
-            mount: typeof mount
-        }
-    }
-}
-
-Cypress.Commands.add('mount', mount)
-
-// Example use:
-// cy.mount(<MyComponent />)
+// The Storybook Knobs addon has an issue with resetting values when you go to a new story.
+// To solve this problem, we have to clear the Knobs state manually every time before running story tests
+afterEach(() => {
+    cy.resetKnobs()
+})

--- a/packages/react-components/cypress/tsconfig.json
+++ b/packages/react-components/cypress/tsconfig.json
@@ -11,6 +11,8 @@
   "include": [
     "./stories/*.ts",
     "./stories/*.tsx",
+    "./support/*.ts",
+    "./utils/*.ts",
     "../stories/*.ts",
     "../stories/*.tsx",
     "../src/*.ts",

--- a/packages/react-components/cypress/utils/gif-test-utils.ts
+++ b/packages/react-components/cypress/utils/gif-test-utils.ts
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import type { IGif } from '@giphy/js-types'
+
+import { Gif } from '../../src'
+import { ComponentEventStubs } from './types'
+
+export type GifEventStubs = ComponentEventStubs<typeof Gif>
+
+export type GifTestUtilsContext = {
+    gifId: string
+    events: GifEventStubs
+}
+
+type BaseAssertOptions = {
+    takeSnapshots?: boolean
+    snapshotNamePrefix?: string
+}
+
+const DEFAULT_BASE_ASSERT_OPTIONS: BaseAssertOptions = {
+    snapshotNamePrefix: 'Gif',
+    takeSnapshots: false,
+}
+
+export function setupGifTestUtils(gifId: string): GifTestUtilsContext {
+    const onGifSeen = cy
+        .stub()
+        .as('onGifSeen')
+        .callsFake((gif: any) => console.log(gif.id))
+    const onGifVisible = cy.stub().as('onGifVisible')
+    const onGifKeyPress = cy.stub().as('onGifKeyPress')
+    const onGifRightClick = cy.stub().as('onGifRightClick')
+    const onGifClick = cy
+        .stub()
+        .as('onGifClick')
+        .callsFake((_: IGif, e: React.MouseEvent) => e.preventDefault())
+
+    return {
+        gifId,
+        events: {
+            onGifSeen,
+            onGifVisible,
+            onGifKeyPress,
+            onGifRightClick,
+            onGifClick,
+        },
+    }
+}
+
+export function getGifRoot(gidId: string) {
+    return cy.get(`[data-cy-root] [data-gph-gif=${gidId}]`)
+}
+
+export function resetGifEventsHistory(ctx: GifTestUtilsContext) {
+    Object.values(ctx.events).forEach((stub) => {
+        cy.wrap(stub).then((s) => s.reset())
+    })
+}
+
+export function checkGifIsVisible(ctx: GifTestUtilsContext, options: BaseAssertOptions = DEFAULT_BASE_ASSERT_OPTIONS) {
+    const { gifId } = ctx
+    const { onGifVisible } = ctx.events
+
+    getGifRoot(gifId).get('img.giphy-img-loaded').should('be.visible')
+    cy.wrap(onGifVisible).should('be.calledBefore', '@onGifSeen').and('be.calledWithMatch', { id: gifId })
+
+    if (options.takeSnapshots) {
+        cy.percySnapshot(`${options.snapshotNamePrefix}: onVisible`)
+    }
+}
+
+export function checkGifSeen(ctx: GifTestUtilsContext, options: BaseAssertOptions = DEFAULT_BASE_ASSERT_OPTIONS) {
+    const { gifId } = ctx
+    const { onGifSeen } = ctx.events
+
+    cy.wrap(onGifSeen).should('be.calledWithMatch', { id: gifId })
+    if (options.takeSnapshots) {
+        cy.percySnapshot(`${options.snapshotNamePrefix}: onVisible`)
+    }
+}
+
+export function checkGifKeyboardEvents(
+    ctx: GifTestUtilsContext,
+    options: BaseAssertOptions = DEFAULT_BASE_ASSERT_OPTIONS
+) {
+    const { gifId } = ctx
+    const { onGifKeyPress } = ctx.events
+
+    getGifRoot(gifId)
+        .focus()
+        .type('g')
+        .then(() => {
+            expect(onGifKeyPress).be.calledOnce.and.calledWithMatch({ id: gifId }, { key: 'g' })
+        })
+
+    if (options.takeSnapshots) {
+        cy.percySnapshot(`${options.snapshotNamePrefix}: onKeyPress`)
+    }
+}
+
+export function checkGifMouseEvents(
+    ctx: GifTestUtilsContext,
+    options: BaseAssertOptions = DEFAULT_BASE_ASSERT_OPTIONS
+) {
+    const { gifId } = ctx
+    const { onGifClick, onGifRightClick } = ctx.events
+
+    getGifRoot(gifId)
+        .click()
+        .then(() => {
+            expect(onGifClick).be.calledOnce.and.be.calledWithMatch({ id: gifId }, {})
+        })
+    if (options.takeSnapshots) {
+        cy.percySnapshot(`${options.snapshotNamePrefix}: onClick`)
+    }
+
+    getGifRoot(gifId)
+        .rightclick()
+        .then(() => {
+            expect(onGifRightClick).be.calledOnce.and.be.calledWithMatch({ id: gifId }, {})
+        })
+    if (options.takeSnapshots) {
+        cy.percySnapshot(`${options.snapshotNamePrefix}: onRightClick`)
+    }
+}

--- a/packages/react-components/cypress/utils/gif-test-utils.ts
+++ b/packages/react-components/cypress/utils/gif-test-utils.ts
@@ -47,7 +47,7 @@ export function setupGifTestUtils(gifId: string): GifTestUtilsContext {
 }
 
 export function getGifRoot(gidId: string) {
-    return cy.get(`[data-cy-root] [data-gph-gif=${gidId}]`)
+    return cy.get(`[data-cy-root] .${Gif.className}[data-giphy-id="${gidId}"]`)
 }
 
 export function resetGifEventsHistory(ctx: GifTestUtilsContext) {
@@ -60,7 +60,7 @@ export function checkGifIsVisible(ctx: GifTestUtilsContext, options: BaseAssertO
     const { gifId } = ctx
     const { onGifVisible } = ctx.events
 
-    getGifRoot(gifId).get('img.giphy-img-loaded').should('be.visible')
+    getGifRoot(gifId).get(`.${Gif.imgLoadedClassName}`).should('be.visible')
     cy.wrap(onGifVisible).should('be.calledBefore', '@onGifSeen').and('be.calledWithMatch', { id: gifId })
 
     if (options.takeSnapshots) {

--- a/packages/react-components/cypress/utils/storybook.ts
+++ b/packages/react-components/cypress/utils/storybook.ts
@@ -1,0 +1,21 @@
+import { manager as knobsManager } from '@storybook/addon-knobs/dist/registerKnobs'
+import type { StoryFile, StoriesWithPartialProps } from '@storybook/testing-react/dist/types'
+
+export function resetKnobs() {
+    knobsManager.knobStore.reset()
+}
+
+export function storiesCompositionToList<TModule extends StoryFile>(
+    composed: Omit<StoriesWithPartialProps<TModule>, keyof StoryFile>
+) {
+    type Keys = keyof typeof composed
+    type Stories = typeof composed[Keys]
+
+    return Object.entries<Stories>(composed).map(
+        ([key, Component]) =>
+            ({
+                Component,
+                key: key as Keys,
+            } as const)
+    )
+}

--- a/packages/react-components/cypress/utils/types.ts
+++ b/packages/react-components/cypress/utils/types.ts
@@ -1,6 +1,15 @@
 import React, { JSXElementConstructor } from 'react'
 import type { SinonStub } from 'cypress/types/sinon'
 
+/* Pick the object keys that represent events. By default, we select all keys that start with "on".
+ * Example:
+ * type MyType = {
+ *  onClick: () => void,
+ *  age: string,
+ *  onSelect: () => void
+ * }
+ * PickEventKeys<MuType> = 'onClick' | 'onSelect'
+ */
 export type PickEventKeys<T extends Record<string, unknown>, TPrefix extends string = 'on'> = keyof T extends infer TKey
     ? TKey extends `${TPrefix}${string}`
         ? TKey
@@ -11,6 +20,20 @@ export type PickComponentEventKeys<T extends keyof JSX.IntrinsicElements | JSXEl
     React.ComponentProps<T>
 >
 
+/* Pick component props that are events based on the prefix (the default is "on") and build a type that represents Sinon stubs for that props.
+ * Example:
+ * type Props = {
+ *  onClick: () => void,
+ *  age: string,
+ *  onSelect: () => void
+ * }
+ * const Component = (props: Props) => {...}
+ *
+ * ComponentEventStubs<typeof Component> == {
+ *  onClick: SinonStub,
+ *  onSelect: SinonStub
+ * }
+ */
 export type ComponentEventStubs<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = Required<
     Record<PickComponentEventKeys<T>, SinonStub>
 >

--- a/packages/react-components/cypress/utils/types.ts
+++ b/packages/react-components/cypress/utils/types.ts
@@ -1,0 +1,16 @@
+import React, { JSXElementConstructor } from 'react'
+import type { SinonStub } from 'cypress/types/sinon'
+
+export type PickEventKeys<T extends Record<string, unknown>, TPrefix extends string = 'on'> = keyof T extends infer TKey
+    ? TKey extends `${TPrefix}${string}`
+        ? TKey
+        : never
+    : never
+
+export type PickComponentEventKeys<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = PickEventKeys<
+    React.ComponentProps<T>
+>
+
+export type ComponentEventStubs<T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>> = Required<
+    Record<PickComponentEventKeys<T>, SinonStub>
+>

--- a/packages/react-components/cypress/utils/video-test-utils.ts
+++ b/packages/react-components/cypress/utils/video-test-utils.ts
@@ -1,0 +1,122 @@
+import VideoComponent from '../../src/components/video'
+import { ComponentEventStubs } from './types'
+
+export type VideoEventStubs = ComponentEventStubs<typeof VideoComponent>
+
+export type VideoTestUtilsContext = {
+    gifId: string
+    loop: boolean
+    events: VideoEventStubs
+}
+
+type TestUtilsOptions = Partial<Pick<VideoTestUtilsContext, 'loop'>>
+
+type BaseAssertOptions = {
+    takeSnapshots?: boolean
+    snapshotNamePrefix?: string
+}
+
+const DEFAULT_BASE_ASSERT_OPTIONS: BaseAssertOptions = {
+    snapshotNamePrefix: 'Video',
+    takeSnapshots: false,
+}
+
+export function setupVideoTestUtils(gifId: string, options: TestUtilsOptions = {}): VideoTestUtilsContext {
+    const onCanPlay = cy.stub().as('onCanPlay')
+    const onEnded = cy.stub().as('onEnded')
+    const onEndFullscreen = cy.stub().as('onEndFullscreen')
+    const onError = cy.stub().as('onError')
+    const onFirstPlay = cy.stub().as('onFirstPlay')
+    const onLoop = cy.stub().as('onLoop')
+    const onMuted = cy.stub().as('onMuted')
+    const onQuartile = cy.stub().as('onQuartile')
+    const onStateChange = cy.stub().as('onStateChange')
+    const onTimeUpdate = cy.stub().as('onTimeUpdate')
+    const onUserMuted = cy.stub().as('onUserMuted')
+    const onWaiting = cy.stub().as('onWaiting')
+
+    return {
+        gifId,
+        loop: options.loop ?? false,
+        events: {
+            onCanPlay,
+            onEnded,
+            onEndFullscreen,
+            onError,
+            onFirstPlay,
+            onLoop,
+            onMuted,
+            onQuartile,
+            onStateChange,
+            onTimeUpdate,
+            onUserMuted,
+            onWaiting,
+        },
+    }
+}
+
+export function getVideoElement(gidId: string): Cypress.Chainable<JQuery<HTMLVideoElement>> {
+    return cy.get(`[data-cy-root] video[data-gph-video="${gidId}"]`)
+}
+
+export function checkVideoIsVisible(
+    ctx: VideoTestUtilsContext,
+    options: BaseAssertOptions = DEFAULT_BASE_ASSERT_OPTIONS
+) {
+    const { gifId } = ctx
+
+    getVideoElement(gifId).should('be.visible')
+    if (options.takeSnapshots) {
+        getVideoElement(gifId).stopVideo()
+        cy.percySnapshot(`${options.snapshotNamePrefix}: onVisible`)
+    }
+}
+
+export function resetVideoEventsHistory(ctx: VideoTestUtilsContext) {
+    Object.values(ctx.events).forEach((stub) => {
+        cy.wrap(stub).then((s) => s.reset())
+    })
+}
+
+export function checkVideoEvents(ctx: VideoTestUtilsContext) {
+    const { gifId, loop, events } = ctx
+
+    cy.wrap(events.onError).should('not.be.called')
+    cy.wrap(events.onFirstPlay).should('be.called')
+    cy.wrap(events.onCanPlay).should('be.called')
+
+    cy.stopVideo()
+    resetVideoEventsHistory(ctx)
+
+    getVideoElement(gifId)
+        .then(async (elems) => {
+            const el = elems.get(0)
+            await el.play()
+            return new Promise((resolve) => {
+                function listener() {
+                    el.removeEventListener('ended', listener)
+                    resolve(null)
+                }
+                el.addEventListener('ended', listener)
+            })
+        })
+        .then(() => {
+            expect(events.onCanPlay).be.calledOnce
+            expect(events.onError).not.be.called
+            expect(events.onFirstPlay).not.be.called
+            expect(events.onEnded).be.calledOnce
+            expect(events.onMuted).not.be.called
+            expect(events.onQuartile).not.be.callCount(4)
+            expect(events.onStateChange).be.calledTwice
+            expect(events.onStateChange?.getCall(0)).be.calledWith('playing')
+            expect(events.onStateChange?.getCall(1)).be.calledWith('paused')
+            expect(events.onTimeUpdate).be.called
+            expect(events.onWaiting).not.be.called
+
+            if (loop) {
+                expect(events.onLoop).be.calledOnce
+            } else {
+                expect(events.onLoop).not.be.called
+            }
+        })
+}

--- a/packages/react-components/cypress/utils/video-test-utils.ts
+++ b/packages/react-components/cypress/utils/video-test-utils.ts
@@ -1,7 +1,8 @@
-import VideoComponent from '../../src/components/video'
+import Video from '../../src/components/video/video'
+import VideoPlayer from '../../src/components/video'
 import { ComponentEventStubs } from './types'
 
-export type VideoEventStubs = ComponentEventStubs<typeof VideoComponent>
+export type VideoEventStubs = ComponentEventStubs<typeof VideoPlayer>
 
 export type VideoTestUtilsContext = {
     gifId: string
@@ -56,7 +57,7 @@ export function setupVideoTestUtils(gifId: string, options: TestUtilsOptions = {
 }
 
 export function getVideoElement(gidId: string): Cypress.Chainable<JQuery<HTMLVideoElement>> {
-    return cy.get(`[data-cy-root] video[data-gph-video="${gidId}"]`)
+    return cy.get(`[data-cy-root] .${Video.className}[data-giphy-id="${gidId}"]`)
 }
 
 export function checkVideoIsVisible(

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -7,7 +7,7 @@
         "prepublish": "npm run clean && tsc",
         "deploy-storybook": "storybook-to-ghpages",
         "snapshot": "NODE_ENV=PERCY build-storybook && percy storybook ./storybook-static",
-        "cy:run": "npx cypress run --component",
+        "cy:run": "npx percy exec -- npx cypress run --component -b chrome",
         "cy:open": "npx cypress open --component -b chrome",
         "cy:verify": "cypress verify",
         "cy:info": "cypress info"
@@ -15,8 +15,9 @@
     "devDependencies": {
         "@babel/core": "^7.18.6",
         "@cypress/react": "^6.0.0",
-        "@percy/cli": "^1.2.1",
-        "@percy/storybook": "4.2.1",
+        "@percy/cli": "^1.6.4",
+        "@percy/cypress": "^3.1.2",
+        "@percy/storybook": "4.3.1",
         "@storybook/addon-actions": "^6.5.9",
         "@storybook/addon-info": "^5.3.21",
         "@storybook/addon-knobs": "^6.4.0",
@@ -31,7 +32,7 @@
         "@types/throttle-debounce": "^2.1.0",
         "awesome-typescript-loader": "^5.2.1",
         "babel-loader": "^8.2.5",
-        "cypress": "^10.3.0",
+        "cypress": "^10.3.1",
         "fetch-mock": "^9.11.0",
         "parcel-bundler": "latest",
         "react": "^18.2.0",
@@ -39,7 +40,7 @@
         "storybook-addon-jsx": "^7.3.14",
         "ts-loader": "^9.3.1",
         "typescript": "^4.7.4",
-        "webpack": "^5.73.0"
+        "webpack": "^5.74.0"
     },
     "name": "@giphy/react-components",
     "version": "5.12.0",
@@ -70,7 +71,6 @@
         "@giphy/js-fetch-api": "^4.3.1",
         "@giphy/js-types": "^4.2.1",
         "@giphy/js-util": "^4.1.1",
-        "@percy/cypress": "^3.1.2",
         "intersection-observer": "^0.12.2",
         "react-use": "17.4.0",
         "throttle-debounce": "^3.0.1"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -7,8 +7,8 @@
         "prepublish": "npm run clean && tsc",
         "deploy-storybook": "storybook-to-ghpages",
         "snapshot": "NODE_ENV=PERCY build-storybook && percy storybook ./storybook-static",
-        "cy:run": "npx percy exec -- npx cypress run --component -b chrome",
-        "cy:open": "npx cypress open --component -b chrome",
+        "cy:run": "percy exec -- cypress run --component -b chrome",
+        "cy:open": "cypress open --component -b chrome",
         "cy:verify": "cypress verify",
         "cy:info": "cypress info"
     },

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -244,7 +244,7 @@ const Gif = ({
     return (
         <Container
             href={noLink ? undefined : gif.url}
-            data-gph-gif={gif.id}
+            data-giphy-id={gif.id}
             style={{
                 width,
                 height,

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -244,6 +244,7 @@ const Gif = ({
     return (
         <Container
             href={noLink ? undefined : gif.url}
+            data-gph-gif={gif.id}
             style={{
                 width,
                 height,

--- a/packages/react-components/src/components/video/video.tsx
+++ b/packages/react-components/src/components/video/video.tsx
@@ -243,6 +243,7 @@ const Video = ({
             playsInline
             ref={videoEl}
             src={media?.url}
+            data-gph-video={gif.id}
         >
             {ccEnabled && captionSrc && (
                 <track label="English" kind="subtitles" srcLang={ccLanguage} src={captionSrc} default />

--- a/packages/react-components/src/components/video/video.tsx
+++ b/packages/react-components/src/components/video/video.tsx
@@ -243,7 +243,7 @@ const Video = ({
             playsInline
             ref={videoEl}
             src={media?.url}
-            data-gph-video={gif.id}
+            data-giphy-id={gif.id}
         >
             {ccEnabled && captionSrc && (
                 <track label="English" kind="subtitles" srcLang={ccLanguage} src={captionSrc} default />

--- a/packages/react-components/stories/attribution.stories.tsx
+++ b/packages/react-components/stories/attribution.stories.tsx
@@ -44,7 +44,9 @@ const makeDummy = (gif: IGif) => {
     return gif
 }
 
-export const Attribution: Story = () => {
+type StoryProps = Partial<React.ComponentProps<typeof AttributionComponent>>
+
+export const Attribution: Story<StoryProps> = (props) => {
     const [gif, setGif] = useState<IGif | undefined>()
     useEffect(() => {
         const f = async () => {
@@ -57,10 +59,11 @@ export const Attribution: Story = () => {
         }
         f()
     }, [])
+
     return gif ? (
         <Container>
             <h3>Standalone attribution</h3>
-            <AttributionComponent gif={makeDummy({ ...gif })} />
+            <AttributionComponent gif={makeDummy({ ...gif })} {...props} />
             <h3>Attribution in GIF component</h3>
             <Gifs>
                 <Gif gif={makeDummy({ ...gif })} width={248} />

--- a/packages/react-components/stories/carousel.stories.tsx
+++ b/packages/react-components/stories/carousel.stories.tsx
@@ -17,7 +17,9 @@ export default {
     decorators: [withKnobs, jsxDecorator],
 }
 
-export const SearchExample: Story = () => {
+type StoryProps = Partial<React.ComponentProps<typeof CarouselComponent>>
+
+export const SearchExample: Story<StoryProps> = (props) => {
     const [term, setTerm] = useState('dogs')
     const limit = number('limit', 5)
     const fetchGifs = async (offset: number) => {
@@ -43,6 +45,7 @@ export const SearchExample: Story = () => {
                 backgroundColor={inTestsRunner() ? 'white' : undefined}
                 gutter={6}
                 fetchGifs={fetchGifs}
+                {...props}
             />
         </>
     )

--- a/packages/react-components/stories/gif.stories.tsx
+++ b/packages/react-components/stories/gif.stories.tsx
@@ -1,9 +1,10 @@
+// @ts-ignore TS2783
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { IGif } from '@giphy/js-types'
 import { Story } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'
-import React, { ElementType, useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { Gif as GifComponent, GifOverlayProps, PingbackContext } from '../src'
 import VideoOverlay from '../src/components/video/video-overlay'
@@ -14,21 +15,15 @@ const eventAction = (event: string) => (gif: IGif) => {
     action(`Gif ${event} for ${gif.id}`)()
 }
 
-const GifDemo = ({
-    id,
-    width,
-    height,
-    noLink,
-    borderRadius,
-    overlay,
-}: {
+type GifComponentProps = React.ComponentProps<typeof GifComponent>
+
+type GifDemoProps = Omit<GifComponentProps, 'gif'> & {
     id: string
-    width: number
-    height?: number
-    noLink?: boolean
-    borderRadius?: number
-    overlay?: ElementType<GifOverlayProps>
-}) => {
+}
+
+type GifStoryProps = Partial<GifDemoProps>
+
+const GifDemo = ({ id, width, height, noLink, borderRadius, overlay, ...other }: GifDemoProps) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = useCallback(async () => {
@@ -54,6 +49,7 @@ const GifDemo = ({
             onGifVisible={eventAction('visible')}
             onGifKeyPress={eventAction('keyPress')}
             overlay={overlay}
+            {...other}
         />
     ) : null
 }
@@ -63,44 +59,62 @@ export default {
     decorators: [withKnobs, jsxDecorator],
 }
 
-export const Gif: Story = () => (
-    <GifDemo id={text('id', 'ZEU9ryYGZzttn0Cva7')} width={number('width', 300)} noLink={boolean('noLink', false)} />
+export const Gif: Story<GifStoryProps> = (props) => (
+    <GifDemo
+        id={text('id', 'ZEU9ryYGZzttn0Cva7')}
+        width={number('width', 300)}
+        noLink={boolean('noLink', false)}
+        {...props}
+    />
 )
 
-export const GifWithVideoOverlay: Story = () => (
+export const GifWithVideoOverlay: Story<GifStoryProps> = (props) => (
     <GifDemo
         id={text('id', 'D068R9Ziv1iCjezKzG')}
         width={number('width', 500)}
         noLink={boolean('noLink', false)}
         overlay={(props: GifOverlayProps) => <VideoOverlay {...props} width={number('width', 500)} />}
+        {...props}
     />
 )
 
-export const GifWithVideoOverlayFillVideo: Story = () => (
+export const GifWithVideoOverlayFillVideo: Story<GifStoryProps> = (props) => (
     <GifDemo
         id={text('id', '3BNRWBatePBETD7Bfg')}
         width={number('width', 500)}
         height={number('height', 300)}
         noLink={boolean('noLink', false)}
         overlay={(props: GifOverlayProps) => <VideoOverlay {...props} width={number('width', 500)} />}
+        {...props}
     />
 )
 
-export const GifNoBorderRadius: Story = () => (
+export const GifNoBorderRadius: Story<GifStoryProps> = (props) => (
     <GifDemo
         id={text('id', 'ZEU9ryYGZzttn0Cva7')}
         borderRadius={0}
         width={number('width', 300)}
         noLink={boolean('noLink', false)}
+        {...props}
     />
 )
 
-export const Sticker: Story = () => (
-    <GifDemo id={text('id', 'l1J9FvenuBnI4GTeg')} width={number('width', 300)} noLink={boolean('noLink', false)} />
+export const Sticker: Story<GifStoryProps> = (props) => (
+    <GifDemo
+        id={text('id', 'l1J9FvenuBnI4GTeg')}
+        width={number('width', 300)}
+        noLink={boolean('noLink', false)}
+        {...props}
+    />
 )
 
-export const CustomPingbackGif: Story = () => (
+export const CustomPingbackGif: Story<GifStoryProps> = (props) => (
     <PingbackContext.Provider value={{ attributes: { 'some key': 'some value' } }}>
-        <GifDemo id={text('id', 'ZEU9ryYGZzttn0Cva7')} width={number('width', 300)} noLink={boolean('noLink', false)} />
+        <GifDemo
+            id={text('id', 'ZEU9ryYGZzttn0Cva7')}
+            width={number('width', 300)}
+            noLink={boolean('noLink', false)}
+            {...props}
+        />
     </PingbackContext.Provider>
 )

--- a/packages/react-components/stories/grid.stories.tsx
+++ b/packages/react-components/stories/grid.stories.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { boolean, number, withKnobs } from '@storybook/addon-knobs'
 import fetchMock from 'fetch-mock'
-import React, { ElementType, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { throttle } from 'throttle-debounce'
 import { GifOverlayProps, Grid as GridComponent } from '../src'
@@ -36,11 +36,9 @@ const NoResultsContainer = styled.div`
 
 const Overlay = ({ gif, isHovered }: GifOverlayProps) => <OverlayContainer>{isHovered ? gif.id : ''}</OverlayContainer>
 
-type GridProps = {
-    loader: ElementType
-}
+type GridProps = Partial<React.ComponentProps<typeof GridComponent>>
 
-export const Grid: Story<GridProps> = ({ loader }) => {
+export const Grid: Story<GridProps> = ({ loader, ...other }) => {
     const [term, setTerm] = useState('always sunny')
     const [width, setWidth] = useState(innerWidth)
     const onResize = throttle(500, () => setWidth(innerWidth))
@@ -82,15 +80,18 @@ export const Grid: Story<GridProps> = ({ loader }) => {
                     loader={loader}
                     fetchGifs={fetchGifs}
                     overlay={boolean('show overlay', true) ? Overlay : undefined}
+                    {...other}
                 />
             )}
         </>
     )
 }
 
-export const GridCustomLoader: Story = () => <Grid loader={() => <h1 style={{ textAlign: 'center' }}> 🌀 </h1>} />
+export const GridCustomLoader: Story<GridProps> = (props) => (
+    <Grid loader={() => <h1 style={{ textAlign: 'center' }}> 🌀 </h1>} {...props} />
+)
 
-export const GridAPIError: Story = () => {
+export const GridAPIError: Story<GridProps> = (props) => {
     const [width, setWidth] = useState(innerWidth)
     const mockRequest = useRef(true)
     const onResize = throttle(500, () => setWidth(innerWidth))
@@ -121,6 +122,7 @@ export const GridAPIError: Story = () => {
             gutter={gutter}
             fetchGifs={fetchGifs}
             overlay={boolean('show overlay', true) ? Overlay : undefined}
+            {...props}
         />
     )
 }

--- a/packages/react-components/stories/in-tests-runner.ts
+++ b/packages/react-components/stories/in-tests-runner.ts
@@ -1,2 +1,4 @@
-const inTestsRunner = () => process.env.NODE_ENV === 'PERCY' || process.env.NODE_ENV === 'cypress'
+const inTestsRunner = () => {
+    return process.env.NODE_ENV === 'PERCY' || !!(window as any).Cypress
+}
 export default inTestsRunner

--- a/packages/react-components/stories/in-tests-runner.ts
+++ b/packages/react-components/stories/in-tests-runner.ts
@@ -1,4 +1,4 @@
 const inTestsRunner = () => {
-    return process.env.NODE_ENV === 'PERCY' || !!(window as any).Cypress
+    return process.env.NODE_ENV === 'PERCY' || (typeof window !== 'undefined' && !!(window as any).Cypress)
 }
 export default inTestsRunner

--- a/packages/react-components/stories/loader.stories.tsx
+++ b/packages/react-components/stories/loader.stories.tsx
@@ -6,6 +6,10 @@ export default {
     title: 'React Components/Loader',
 }
 
-export const DotsLoader: Story = () => {
-    return <DotsLoader_ />
+type DotsLoaderProps = React.ComponentProps<typeof DotsLoader_>
+
+type StoryProps = Partial<DotsLoaderProps>
+
+export const DotsLoader: Story<StoryProps> = (props) => {
+    return <DotsLoader_ {...props} />
 }

--- a/packages/react-components/stories/video-player.stories.tsx
+++ b/packages/react-components/stories/video-player.stories.tsx
@@ -28,7 +28,9 @@ export default {
     decorators: [withKnobs, jsxDecorator],
 }
 
-export const VideoWithControls: Story = () => {
+type StoryProps = Partial<React.ComponentProps<typeof VideoPlayer>>
+
+export const VideoWithControls: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -37,13 +39,14 @@ export const VideoWithControls: Story = () => {
             height={number('height', 0)}
             muted={boolean('muted', false)}
             gif={gif}
+            {...props}
         />
     ) : (
         <div>video loading</div>
     )
 }
 
-export const VideoNoAttribution: Story = () => {
+export const VideoNoAttribution: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -53,13 +56,14 @@ export const VideoNoAttribution: Story = () => {
             width={number('width', 300)}
             height={number('height', 0)}
             muted={boolean('muted', false)}
+            {...props}
         />
     ) : (
         <div>video loading</div>
     )
 }
 
-export const VideoNoProgressBar: Story = () => {
+export const VideoNoProgressBar: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -69,13 +73,14 @@ export const VideoNoProgressBar: Story = () => {
             width={number('width', 300)}
             height={number('height', 0)}
             muted={boolean('muted', false)}
+            {...props}
         />
     ) : (
         <div>video loading</div>
     )
 }
 
-export const VideoNoMute: Story = () => {
+export const VideoNoMute: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -85,13 +90,14 @@ export const VideoNoMute: Story = () => {
             width={number('width', 300)}
             height={number('height', 0)}
             muted={boolean('muted', false)}
+            {...props}
         />
     ) : (
         <div>video loading</div>
     )
 }
 
-export const VideoPersistentControlsSmall: Story = () => {
+export const VideoPersistentControlsSmall: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -101,13 +107,14 @@ export const VideoPersistentControlsSmall: Story = () => {
             width={number('width', 300)}
             height={number('height', 0)}
             muted={boolean('muted', false)}
+            {...props}
         />
     ) : (
         <div>video loading</div>
     )
 }
 
-export const VideoPersistentControlsMedium: Story = () => {
+export const VideoPersistentControlsMedium: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -117,13 +124,14 @@ export const VideoPersistentControlsMedium: Story = () => {
             width={number('width', 400)}
             height={number('height', 0)}
             muted={boolean('muted', false)}
+            {...props}
         />
     ) : (
         <div>video loading</div>
     )
 }
 
-export const VideoPersistentControlsLarge: Story = () => {
+export const VideoPersistentControlsLarge: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -133,6 +141,7 @@ export const VideoPersistentControlsLarge: Story = () => {
             width={number('width', 600)}
             height={number('height', 0)}
             muted={boolean('muted', false)}
+            {...props}
         />
     ) : (
         <div>video loading</div>
@@ -145,7 +154,8 @@ const Overlay = styled.div`
     bottom: 5px;
     right: 5px;
 `
-export const VideoOverlay: Story = () => {
+
+export const VideoOverlay: Story<StoryProps> = (props) => {
     const gif = useGif(text('id', 'WtUBmrAK1Yda649Ayr'))
     return gif ? (
         <VideoPlayer
@@ -155,6 +165,7 @@ export const VideoOverlay: Story = () => {
             height={number('height', 0)}
             muted={boolean('muted', true)}
             overlay={() => <Overlay>OVERLAY</Overlay>}
+            {...props}
         />
     ) : (
         <div>video loading</div>

--- a/packages/react-components/stories/video.stories.tsx
+++ b/packages/react-components/stories/video.stories.tsx
@@ -15,7 +15,9 @@ const eventAction = (event: string) => {
 
 type Props = { id: string } & Partial<ComponentProps<typeof VideoComponent>>
 
-const VideoDemo = ({ id, width, height, muted, ccEnabled }: Props) => {
+type StoryProps = Partial<Props>
+
+const VideoDemo = ({ id, width, height, muted, ccEnabled, ...other }: Props) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = useCallback(async () => {
@@ -42,6 +44,7 @@ const VideoDemo = ({ id, width, height, muted, ccEnabled }: Props) => {
             onWaiting={(count: number) => eventAction(`on waiting: ${count}`)}
             ccEnabled={ccEnabled}
             // onTimeUpdate={(t) => console.log(t)}
+            {...other}
         />
     ) : null
 }
@@ -51,16 +54,17 @@ export default {
     decorators: [withKnobs, jsxDecorator],
 }
 
-export const Video: Story = () => (
+export const Video: Story<StoryProps> = (props) => (
     <VideoDemo
         id={text('id', 'D068R9Ziv1iCjezKzG')}
         width={number('width', 300)}
         height={number('height', 0)}
         muted={boolean('muted', false)}
+        {...props}
     />
 )
 
-export const VideoCaptionsBeta: Story = () => (
+export const VideoCaptionsBeta: Story<StoryProps> = (props) => (
     <>
         <h3 style={{ color: 'white' }}>Beta Feature</h3>
         <VideoDemo
@@ -69,24 +73,27 @@ export const VideoCaptionsBeta: Story = () => (
             height={number('height', 0)}
             muted={boolean('muted', true)}
             ccEnabled={boolean('ccEnabled', true)}
+            {...props}
         />
     </>
 )
 
-export const VideoUserMuted: Story = () => (
+export const VideoUserMuted: Story<StoryProps> = (props) => (
     <VideoDemo
         id={text('id', 'obhOJFSwuTRN7VDY55')}
         width={number('width', 300)}
         height={number('height', 0)}
         muted={boolean('muted', true)}
+        {...props}
     />
 )
 
-export const VideoNoContent: Story = () => (
+export const VideoNoContent: Story<StoryProps> = (props) => (
     <VideoDemo
         id={text('id', 'ZEU9ryYGZzttn0Cva7')}
         width={number('width', 300)}
         height={number('height', 0)}
         muted={boolean('muted', true)}
+        {...props}
     />
 )

--- a/packages/react-components/yarn.lock
+++ b/packages/react-components/yarn.lock
@@ -1914,123 +1914,123 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
-"@percy/cli-build@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.6.1.tgz#f49e6df1ca3b2f548c853c66f75ebb407e2302ea"
-  integrity sha512-YP4+uLfT14zI1bfjU+VE8fhu6RkwuhRK1AHIFcbonj/HlIhCdFWqyrWcmLp6HYU06JoiNtbI4QQNM3spxWrolg==
+"@percy/cli-build@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.6.4.tgz#965bfeaa069bce1b578589aff6f7bb3fa1f6a7fc"
+  integrity sha512-OC8cPqI+Q12h6P/W93JC5dR2QBKjuNKPs5UmLWYQvkXp24igex0ZeJYZUqvpJrxj4Fm4PTbEmn3SLDo/s86QOg==
   dependencies:
-    "@percy/cli-command" "1.6.1"
+    "@percy/cli-command" "1.6.4"
 
-"@percy/cli-command@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.1.tgz#e41b47d038e9ce52ffeeabba19d707468670829d"
-  integrity sha512-5jeKsKM+it3gh93vV48dBi725ewVGOfxUsjZU8slKcK9IaohXkjr0/aWor9LWgQcug87sLS9VjNlc+UyhTW0KA==
+"@percy/cli-command@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.4.tgz#828cc900717aa53c62d65349ce656285b9c4c8b2"
+  integrity sha512-is7ZFk1GbBajP3c16Pm+QBIyYE7371s5Os8VuTr4vyGOyYtR9s2wKS1EPzoUhKOZRDlJ1fAi4/PQQiZVZqd2IA==
   dependencies:
-    "@percy/config" "1.6.1"
-    "@percy/core" "1.6.1"
-    "@percy/logger" "1.6.1"
+    "@percy/config" "1.6.4"
+    "@percy/core" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/cli-command@^1.2.1":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.0.tgz#3227e5429adfaf1ff8bd170df571f72c46286beb"
-  integrity sha512-seJ3bkRKS1Nmf9GLE1K5Mqvl01MdejmWD9c6kuYcJndGGkwp6xqUDjhbtIHPxFp1UOTa7b6cb0CT6o01C7VjmQ==
+"@percy/cli-command@^1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.6.3.tgz#e209cd4410cd8b6a0e130f48258173080bcdce96"
+  integrity sha512-WHICKTVdLW8vFm0emBkR/tV14XKWUfUEKw9UieSuEwIrQmMTPEaY0GxuRk3NrBMj6vkRuJW6yeLCGLVWFlRGlQ==
   dependencies:
-    "@percy/config" "1.6.0"
-    "@percy/core" "1.6.0"
-    "@percy/logger" "1.6.0"
+    "@percy/config" "1.6.3"
+    "@percy/core" "1.6.3"
+    "@percy/logger" "1.6.3"
 
-"@percy/cli-config@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.6.1.tgz#f34c72fda6f9903770bb725693b8c7dbbad21150"
-  integrity sha512-fUO14gra2EdvY0RT5eSxH8QhammDtclcb2vjTwMG6QUW+sGDQQCu8M8s7YBxRKo/aTq+tJy1hfqd6W/rsx0mWQ==
+"@percy/cli-config@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.6.4.tgz#10b6acae399a4b5b066f45096b63614940a225ef"
+  integrity sha512-kDwuMnrmc1iRtMVQIHoawRxkeaDLLJ+ksx9TLsp+GdEkfXU8rLoxugZh9Aey1/E5R5cjz8Esqi0LB7Ii7qmnZw==
   dependencies:
-    "@percy/cli-command" "1.6.1"
+    "@percy/cli-command" "1.6.4"
 
-"@percy/cli-exec@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.6.1.tgz#736e5f2c09080e19ebbcf84c1ded13c5e7db2b0b"
-  integrity sha512-F8j+reJWPu0s+zQuEU2Gm8SZ1QP7cf04MS5hmL1CaE7G7O88ec+yrS6eiSlNrY1+D45B7NYy7l6zWzsP+nQ3TA==
+"@percy/cli-exec@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.6.4.tgz#736882c5d317845c00988200d86d5b2409767d87"
+  integrity sha512-pC5gx5RxJY0baOJ5CyLCwFBVhN0luOm0F9S/EMvRg3CZAWy6IiJMWth3lRYQo7mG7s9AOzcEOyfZ+20YKGc6bQ==
   dependencies:
-    "@percy/cli-command" "1.6.1"
+    "@percy/cli-command" "1.6.4"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.6.1.tgz#0da90a1cf6f7e79898f4f68f1e180c8c7c8f2894"
-  integrity sha512-lrZR/CIL1zkZdeOPmnidkVtWY6foOq3ekWbaoMgDu0agMjf2lxEX2DvkCS/WwdmF/JvDcquLKO6gS5EHE6mbBQ==
+"@percy/cli-snapshot@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.6.4.tgz#ceb2280644fb6cde6f641736dd85664c4f093a76"
+  integrity sha512-+rN58q/mz05mr94L8FfPqTMGEoLAsq9D28IHZmM94Y5O0mCYqPEpVZgbvkkrz+UfFrqyMtR3WGCqs4mJpE97cA==
   dependencies:
-    "@percy/cli-command" "1.6.1"
+    "@percy/cli-command" "1.6.4"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.6.1.tgz#ffd95ca03d15081a77d9090d1c33b32044db849e"
-  integrity sha512-F+n7gy5CTfR0BUSsFdxEpfb9CNDnnhnFO0AN9v2FfyiSEei3CXrS2Te6DJS/YXnVI58YeFRbiW6G1LKhP+Vi4g==
+"@percy/cli-upload@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.6.4.tgz#f7f2f177401b70cf6f80827f88073e85ec86694d"
+  integrity sha512-OFZ9xwnJbQpMQRCVVhXKDFmuLEc+tcx9NZ20UNrEpyjlndlfrCBZPBQVrqhonZ1oBhVBRSoRj0iw+BF6YDdboA==
   dependencies:
-    "@percy/cli-command" "1.6.1"
+    "@percy/cli-command" "1.6.4"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.2.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.6.1.tgz#d3910dd63d2b2b67e57e4c9c675eafb4d471322a"
-  integrity sha512-BwCcigFixUhi2Wn6X+oucJrqnk/6e4FOsYQI4+lDzZU416+WpsYF0CjmhQVpa9Us278L+qc7eIsDHJwuJeurFw==
+"@percy/cli@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.6.4.tgz#01e943cc78de42bc05ebbff08f7ac1deeb17ff21"
+  integrity sha512-K1Dgtt7aB/db/oSRdLTCxHZ1AY/gziDrDHxWXRMSgsbf+PunnWe6qUfhxqqLbqlizf8ccp608beKWtys/xKrGw==
   dependencies:
-    "@percy/cli-build" "1.6.1"
-    "@percy/cli-command" "1.6.1"
-    "@percy/cli-config" "1.6.1"
-    "@percy/cli-exec" "1.6.1"
-    "@percy/cli-snapshot" "1.6.1"
-    "@percy/cli-upload" "1.6.1"
-    "@percy/client" "1.6.1"
-    "@percy/logger" "1.6.1"
+    "@percy/cli-build" "1.6.4"
+    "@percy/cli-command" "1.6.4"
+    "@percy/cli-config" "1.6.4"
+    "@percy/cli-exec" "1.6.4"
+    "@percy/cli-snapshot" "1.6.4"
+    "@percy/cli-upload" "1.6.4"
+    "@percy/client" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/client@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.0.tgz#33470d20891ddfcfc4a3f1a6d3c2b0c404eada75"
-  integrity sha512-pUC1ZUaCpHcKCORIOrE/Y2+7LgELGX/s0X3INCFMIiFcgQK+FyQAjV+0x4MG+FJJvtxfj5WoP4LVu1XWlbyHrg==
+"@percy/client@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.3.tgz#7d75af3b92e3548fae70239cc16e4a832ae520e6"
+  integrity sha512-/gsfhikO3O36vWHH6TQ4QSVp/i1GkTt7lyPEn51jzKjV9rdQ8hmvxzMk2mleyYDAlZQBwyQaOZdMnhfbphLM2w==
   dependencies:
-    "@percy/env" "1.6.0"
-    "@percy/logger" "1.6.0"
+    "@percy/env" "1.6.3"
+    "@percy/logger" "1.6.3"
 
-"@percy/client@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.1.tgz#6bb136c2fe0ab0490acc898de21f8ab3508420a5"
-  integrity sha512-e5ToG88O1gDDOuQ+i4989vKCfF+CsPSGG9VA06IKSYNP4QBATe9/RYERZ5jk118uEutjxi8lIjzet0eg8rv7BA==
+"@percy/client@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.6.4.tgz#ac7fd6c98144661574dc028587935570c706a7d3"
+  integrity sha512-LbJg/xhrXavHx4ZiijpAq5fpELKszePF0kGMvBHFeEorVjqTPmkZQg1pQW480ND+F/h6sLk15ucU0Aylp2eooA==
   dependencies:
-    "@percy/env" "1.6.1"
-    "@percy/logger" "1.6.1"
+    "@percy/env" "1.6.4"
+    "@percy/logger" "1.6.4"
 
-"@percy/config@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.0.tgz#5e720c76fca8cb8872257b3a6630ffad1fce4e36"
-  integrity sha512-g5wDYRqyrSxoTszLxmw/cb1DIjuc91uYQZNVjNc7TWtX8Rvlvbr1fOhaLq5/bmB8N6kLP2sXmcdz9zO4Fuw53g==
+"@percy/config@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.3.tgz#381e2b1f64593b651c90aeca911979cae5867f3f"
+  integrity sha512-BKDykqRoBrjeUHhfYLuTrAnxFYTuOXHc6XKmHuui44buoF5ZaG/2Md5DQpqfGVQ0Jdzumoge/up7PGmxdve1SQ==
   dependencies:
-    "@percy/logger" "1.6.0"
+    "@percy/logger" "1.6.3"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/config@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.1.tgz#11fb960dca4ecc0575349382a973b6c5c941363a"
-  integrity sha512-UiB4gpt01VgPUF4ObZBixR1Wwi/ZUaMXBUxmE3wOa3zZrtZXOzbZwQGcntw5ToEq6OQBP100q1vetnP8xhFQtQ==
+"@percy/config@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.6.4.tgz#31812d1f949f22f6589e87027716d29271822e67"
+  integrity sha512-e9e6CneEs2nmY3kstr5SNaoXT7LRk3Ga/noioSA5HNWPMqKPRwZaMlYLWA0NMSCbVcShMAqbRpa4FEbYTbpGGw==
   dependencies:
-    "@percy/logger" "1.6.1"
+    "@percy/logger" "1.6.4"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.0.tgz#ff2c29a11883f6251a5e664dfb130a1296f69a99"
-  integrity sha512-pXqzmg84cQO39xAT90RChnh7R2Xfv7e3Tu0z1/pEO7/TbxAbMFN5xjLYEXExmbvRlBZ1aMlhjfeHMcMWodyC8A==
+"@percy/core@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.3.tgz#a22c12e09d1e43aa6e72494ce94acae7beb8923d"
+  integrity sha512-RwRh8UUARv2gtD32C0NNe6VbBAWhne6IUBN5nMJ2yw6Q7LZqf2oa8kiocxGlyXpMTjYDRZ/FbNT0PqFw5o52gw==
   dependencies:
-    "@percy/client" "1.6.0"
-    "@percy/config" "1.6.0"
-    "@percy/dom" "1.6.0"
-    "@percy/logger" "1.6.0"
+    "@percy/client" "1.6.3"
+    "@percy/config" "1.6.3"
+    "@percy/dom" "1.6.3"
+    "@percy/logger" "1.6.3"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2041,15 +2041,15 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/core@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.1.tgz#f18681ba4ba1d8f25cfe2c624424749ae0b2590a"
-  integrity sha512-a4EeoynE4pU7qExfLr56nmZNu3ozeCNFk6rCBQqoXbSJy6UVG8nj7U8AWEPeBHqtdk2M+30YAVr6mJCQjkZZ7w==
+"@percy/core@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.6.4.tgz#8dc8b78e175b7312ab00ce05043f2b2d07861e09"
+  integrity sha512-p5XP8gcKqeozcJSPZS9ynVfuGV2rM9dYPCjL0GX7KRkjY9vpAO6IfDAFUbcJYbbwy54WiJqFjDMmm8xmTsVniQ==
   dependencies:
-    "@percy/client" "1.6.1"
-    "@percy/config" "1.6.1"
-    "@percy/dom" "1.6.1"
-    "@percy/logger" "1.6.1"
+    "@percy/client" "1.6.4"
+    "@percy/config" "1.6.4"
+    "@percy/dom" "1.6.4"
+    "@percy/logger" "1.6.4"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -2067,50 +2067,49 @@
   dependencies:
     "@percy/sdk-utils" "^1.3.1"
 
-"@percy/dom@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.0.tgz#15a9363ad45757b71287fa0ef982f58d69877311"
-  integrity sha512-yy5BCSTS6q0aOaA0v5kthgl/Ap8GPTJNfjmMTZxOjsxZ5WpVWWgMItkLo/sWcV77YJQG+Q343xCd/+thH393NA==
+"@percy/dom@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.3.tgz#cd2bf2569ba328f886ba9e026498a060fd980ffc"
+  integrity sha512-V4D/og0AOI1uFb5xtRYuypjmG6PuVwe+eMz10hFThRsxCiRGKlS7QnZUyNQkRwIO/k2r7LnboBpIUzBakSCgzA==
 
-"@percy/dom@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.1.tgz#8b8e82817dd88f8497ffce2d8fc5480466cbfef3"
-  integrity sha512-TAVGiE/7imR3Q6z1ogZFufX+SsPrElBOYNmj+MOFVJyzJ/cTjA9B510Blx1nXTu2VNdK2GAmRGQPbZDty34YMg==
+"@percy/dom@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.6.4.tgz#3a823b2138055ac4a0804d8802e849282adbebd7"
+  integrity sha512-1Ox++5ZpbleaERifm+NTgSgSWKpAFSIxd5x4ZUI6HzNlojDverat6nIFjU+q5Y4Y2DHXn5ihagvODqspOq0Dkw==
 
-"@percy/env@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.0.tgz#47cc9a886a3ab1045c1bbff30831fad16abb485a"
-  integrity sha512-nQpAspFtKdU7fwyVyEY+JtWMohrRfPug6osLRV6DmZnBvT9SLJ4Fh67W06xOGL6PBGiWLuCKyS5d7tJi+WWkUw==
+"@percy/env@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.3.tgz#ab9ff1f3cd85d77be409206d6469fa580efe5164"
+  integrity sha512-YsGQa6i/8Ca+XblRFxAClIo18dEYrU/rZKTZEio4WJ59zjoTskOU3VTgH4a4LX7J3LRpy0+A3v8UiUI4y3Vf8g==
 
-"@percy/env@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.1.tgz#5119de7526e006242b76688c24e94822113af139"
-  integrity sha512-AguYuqRcKHkCnWndvq1pTrxeUXT0mNULSi9p7D0nN1744036RcdVrE/EhZbgK2fshSHxIrnfPSj0Lnt4Of46lg==
+"@percy/env@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.6.4.tgz#80cb8dd2b44cdce3318cdde752fc183a1553ffa5"
+  integrity sha512-zn/RqbxSOtSnV8rApLtJ7EVzFdPVv+Agwq85/UuTK+2Md5Eb+mnT6TbmkRg/0n7l8d14uiDcRRwRi1+msVefZg==
 
-"@percy/logger@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.0.tgz#09653444013ba3bae152543c8721e6c9e025d2d5"
-  integrity sha512-4Y3dQdVDgFtEHtou2IVSNqaxGNOp0QeVWGx/4wbxchrPh8fXpBcXuYRHQRgpH+vDlb8pdx7cOFSlGJuOXN8LMw==
+"@percy/logger@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.3.tgz#c13c64c20f9f842fe36266abbddfe9f07cfd2b6a"
+  integrity sha512-900DQ6KmDZVADuVdPARpZHvodALrswLOd/z4x2du484o/hyiNtO2nvO3rzyTCPVI+nreMT82yCy3JqnNwtJaSQ==
 
-"@percy/logger@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.1.tgz#754e3bdaa4419aadc2d7fa95b63f4ef757483cd4"
-  integrity sha512-cOMzDbg6Or1SnyzT9xCnwIiMDQ4sUR7Ha91CE6NWpV273Ef5PtvBA0joIB7wWSe7t2/a8hQrYJ6eGU4rUcsuTw==
+"@percy/logger@1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.6.4.tgz#598f1a5de0af9f8e3616a9d12ebf6fedbed5da78"
+  integrity sha512-lFPlVcxRtQyFw+TGzfOgFm4Vc/e8xx3nrrdKopnm22JIiTGH/hYFmq4A9u0e4b6Sp2nDZzWT2W5fxVHZiKDDlg==
 
 "@percy/sdk-utils@^1.3.1":
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.6.3.tgz#3a21fc90578d682c7cc36ecb5487664a026a4ca0"
   integrity sha512-Q3x88t04BYd9glJYAClm/B0FMhEEIj69ExKQhbCjXWVuH7M5gvRdfImNiZQq5QevgeYcKwhPmO2CEkYhTO5Vig==
 
-"@percy/storybook@4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@percy/storybook/-/storybook-4.2.1.tgz#446b38f91e6707cb1a98443a2614f043b52832b4"
-  integrity sha512-fJaMwDcdPeV7hAliZ4hc7gXoGZnQI7Yek3zMaLZjjC+nWZREAFl9eI3cdHo7wSZjNCtzEVM3NhE32RpfbwCRyQ==
+"@percy/storybook@4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@percy/storybook/-/storybook-4.3.1.tgz#6acd8ebfa03e44e11e39fdd8cad11aa7e494b68d"
+  integrity sha512-o/xUlA2JydaTmVWSzvZzFPuNvVI9+T+FK+02uN8NaJ2dZ+QpAEwq+hlqWy8QMhAuia7MZ38bLr8MMHcItUytoA==
   dependencies:
-    "@percy/cli-command" "^1.2.1"
-    "@storybook/router" "~6.4.22"
+    "@percy/cli-command" "^1.6.3"
+    "@storybook/router" "^6.5.0"
     cross-spawn "^7.0.3"
-    qs "^6.10.3"
 
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
@@ -2606,14 +2605,6 @@
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.3.4.tgz#c7ee70463c48bb3af704165d5456351ebb667fc2"
   integrity sha512-Gu4M5bBHHQznsdoj8uzYymeojwWq+CRNsUUH41BQIND/RJYSX1IYGIj0yNBP449nv2pjHcTGlN8NJDd+PcELCQ==
-  dependencies:
-    core-js "^3.8.2"
-    global "^4.4.0"
-
-"@storybook/client-logger@6.4.22":
-  version "6.4.22"
-  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.4.22.tgz#51abedb7d3c9bc21921aeb153ac8a19abc625cd6"
-  integrity sha512-LXhxh/lcDsdGnK8kimqfhu3C0+D2ylCSPPQNbU0IsLRmTfbpQYMdyl0XBjPdHiRVwlL7Gkw5OMjYemQgJ02zlw==
   dependencies:
     core-js "^3.8.2"
     global "^4.4.0"
@@ -3331,7 +3322,7 @@
     qs "^6.10.0"
     ts-dedent "^2.0.0"
 
-"@storybook/router@6.5.9":
+"@storybook/router@6.5.9", "@storybook/router@^6.5.0":
   version "6.5.9"
   resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.5.9.tgz#4740248f8517425b2056273fb366ace8a17c65e8"
   integrity sha512-G2Xp/2r8vU2O34eelE+G5VbEEVFDeHcCURrVJEROh6dq2asFJAPbzslVXSeCqgOTNLSpRDJ2NcN5BckkNqmqJg==
@@ -3341,23 +3332,6 @@
     memoizerific "^1.11.3"
     qs "^6.10.0"
     regenerator-runtime "^0.13.7"
-
-"@storybook/router@~6.4.22":
-  version "6.4.22"
-  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.4.22.tgz#e3cc5cd8595668a367e971efb9695bbc122ed95e"
-  integrity sha512-zeuE8ZgFhNerQX8sICQYNYL65QEi3okyzw7ynF58Ud6nRw4fMxSOHcj2T+nZCIU5ufozRL4QWD/Rg9P2s/HtLw==
-  dependencies:
-    "@storybook/client-logger" "6.4.22"
-    core-js "^3.8.2"
-    fast-deep-equal "^3.1.3"
-    global "^4.4.0"
-    history "5.0.0"
-    lodash "^4.17.21"
-    memoizerific "^1.11.3"
-    qs "^6.10.0"
-    react-router "^6.0.0"
-    react-router-dom "^6.0.0"
-    ts-dedent "^2.0.0"
 
 "@storybook/semver@^7.3.2":
   version "7.3.2"
@@ -4193,6 +4167,11 @@ acorn@^8.4.1, acorn@^8.5.0:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+
+acorn@^8.7.1:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -6264,10 +6243,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.0.tgz#fae8d32f0822fcfb938e79c7c31ef344794336ae"
-  integrity sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==
+cypress@^10.3.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
+  integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
@@ -6870,7 +6849,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.0.0:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
   integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
@@ -8306,20 +8285,6 @@ highlight.js@~9.13.0:
   version "9.13.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.13.1.tgz#054586d53a6863311168488a0f58d6c505ce641e"
   integrity sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==
-
-history@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
-  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
-history@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
-  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -11851,13 +11816,6 @@ qs@^6.10.0, qs@^6.6.0, qs@^6.9.4:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.10.3:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
-  dependencies:
-    side-channel "^1.0.4"
-
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -12183,21 +12141,6 @@ react-refresh@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
-
-react-router-dom@^6.0.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
-  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
-  dependencies:
-    history "^5.2.0"
-    react-router "6.3.0"
-
-react-router@6.3.0, react-router@^6.0.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
-  dependencies:
-    history "^5.2.0"
 
 react-select@^3.2.0:
   version "3.2.0"
@@ -14700,6 +14643,14 @@ watchpack@^2.2.0, watchpack@^2.3.1:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+watchpack@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
@@ -14855,21 +14806,21 @@ webpack@4:
     watchpack "^2.3.1"
     webpack-sources "^3.2.3"
 
-webpack@^5.73.0:
-  version "5.73.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.73.0.tgz#bbd17738f8a53ee5760ea2f59dce7f3431d35d38"
-  integrity sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==
+webpack@^5.74.0:
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
+    acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.9.3"
+    enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -14882,7 +14833,7 @@ webpack@^5.73.0:
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.1"
+    watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:


### PR DESCRIPTION
In this PR, I added Cypress specs for all the stories except the SearchBar and updated the Cypress settings a bit. These simple specs do Percy snapshots and test component events. In the future, we can extend these specs by adding test cases to reflect the problems we encounter.

I disabled the "snapshot" command in the Travis pipeline to avoid the Percy screenshot mess. All snapshots should now be taken within the Cypress specs, which allow us to control visual drifting and do snapshots that match the desired component states.   

Note. I assume we can have visual drifting with Gifs because we have no guarantee that every time we do a Percy snapshot, we do so on the same Gif frames. But I think this is a challenge for the future. For example, we can switch Cypress tests to Firefox runner because Firefox allows us to disable auto-play Gifs or extend the "cy.percySnapshot" command, which will replace the gif on the first frame before the snapshot and then roll back the changes.