### PR TITLE
Add opt-in props for pingback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,48 @@
 language: node_js
+os: linux
 node_js:
-    - '14'
+  - '14'
 
 env:
-    # skip Puppeteer download, only needed for Netlify build
-    - PUPPETEER_SKIP_DOWNLOAD=1
+  # skip Puppeteer download, only needed for Netlify build
+  - PUPPETEER_SKIP_DOWNLOAD=1
 
 addons:
-    apt:
-        packages:
-            - libgconf-2-4
+  apt:
+    packages:
+      - libgconf-2-4
 
 cache:
-    yarn: true
-    directories:
-        - 'node_modules'
-        - '~/.cache'
+  yarn: true
+  directories:
+    - 'node_modules'
+    - '~/.cache'
 
 before_script:
-    - yarn global add license-checker
-    - yarn run lerna bootstrap
-    - git checkout .
-    - yarn run cy:verify
-    - yarn run cy:info
+  - yarn global add license-checker
+  - yarn run lerna bootstrap
+  - git checkout .
+  - yarn run cy:verify
+  - yarn run cy:info
 
 script:
-    - yarn run check-licenses
-    - yarn run dependency-cruiser
-    - yarn run lint
-    - yarn test
-    # All Percy snapshots except SearchBar have been moved to Cypress, to avoid confusion disable the old "snapshot" command.
-    # When the Cypress setuisbe verified, this command might be removed.
-    # - yarn run snapshot
-    - yarn run cy:run --record --key ${CYPRESS_RECORD_KEY}
-    # after all tests finish running we need
-    # to kill all background jobs (like "npm start &")
-    # this avoids flake in Travis jobs
-    - kill $(jobs -p) || true
+  - yarn run check-licenses
+  - yarn run dependency-cruiser
+  - yarn run lint
+  - yarn test
+  # All Percy snapshots except SearchBar have been moved to Cypress, to avoid confusion disable the old "snapshot" command.
+  # When the Cypress setuisbe verified, this command might be removed.
+  # - yarn run snapshot
+  - yarn run cy:run --record --key ${CYPRESS_RECORD_KEY}
 
 before_deploy:
-    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" >> $HOME/.npmrc
 
 deploy:
-    if: branch = master AND tag IS present
-    provider: script
+  - provider: script
     script: 'yarn run lerna:publish'
+    cleanup: false
     skip_cleanup: true
     on:
-        tags: true
-        condition: $TRAVIS_COMMIT_MESSAGE =~ ^Publish
+      branch: master
+      condition: $TRAVIS_COMMIT_MESSAGE =~ ^Publish

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -3,7 +3,8 @@
         "clean": "rm -rf ./dist",
         "dev": "parcel public/test.html",
         "build": "tsc",
-        "prepublish": "npm run clean && npm run build"
+        "prepublish": "npm run clean && npm run build",
+        "test": "tsc --noEmit"
     },
     "devDependencies": {
         "parcel-bundler": "latest",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -34,6 +34,7 @@ _renderGrid options_
 | gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
 | noResultsMessage                        | `string \| element`                      | undefined | Customise the "No results" message                                                                    |
 | noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| optInToTelemetry                        | `boolean`                                | false     | Opt-in to sending telemetry events to Giphy on certain user interactions                              |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                                                         |
 | [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                             |
 
@@ -91,16 +92,17 @@ grid.remove()
 
 _renderCarousel options_
 
-| property                                | type                                     | default   | description                                                                                           |
-| --------------------------------------- | ---------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
-| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                                               |
-| gifWidth                               | `number`                                 | undefined | The width of the gifs and the carousel (you may want to set Gif.imgClassName to have object-fit: cover to avoid stretching)                                                              |
-| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                              |
-| gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                    |
-| noResultsMessage                        | `string \| element`                      | undefined | Customise the "No results" message                                                                    |
-| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                                                         |
-| noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
-| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                             |
+| property                                | type                                     | default   | description                                                                                                                 |
+| --------------------------------------- | ---------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| gifHeight                               | `number`                                 | undefined | The height of the gifs and the carousel                                                                                     |
+| gifWidth                                | `number`                                 | undefined | The width of the gifs and the carousel (you may want to set Gif.imgClassName to have object-fit: cover to avoid stretching) |
+| fetchGifs                               | `(offset:number) => Promise<GifsResult>` | undefined | A function that returns a Promise<GifsResult>. Use `@giphy/js-fetch-api`                                                    |
+| gutter                                  | `number`                                 | 6         | The space between columns and rows                                                                                          |
+| noResultsMessage                        | `string \| element`                      | undefined | Customise the "No results" message                                                                                          |
+| noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick`                       |
+| optInToTelemetry                        | `boolean`                                | false     | Opt-in to sending telemetry events to Giphy on certain user interactions                                                    |
+| [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a                                                                               |
+| [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                                                   |
 
 ```typescript
 import { renderCarousel } from '@giphy/js-components'
@@ -133,8 +135,9 @@ _Gif props_
 | gif                                     | `IGif`    | undefined          | The gif to display                                                                                    |
 | width                                   | `number`  | undefined          | The width of the gif                                                                                  |
 | backgroundColor                         | `string`  | random giphy color | The background of the gif before it loads                                                             |
-| [hideAttribution](#attribution-overlay) | `boolean` | false              | Hide the user attribution that appears over a GIF                                                     |
 | noLink                                  | `boolean` | false              | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| optInToTelemetry                        | `boolean` | false              | Opt-in to sending telemetry events to Giphy on certain user interactions                              |
+| [hideAttribution](#attribution-overlay) | `boolean` | false              | Hide the user attribution that appears over a GIF                                                     |
 | [Gif Events](#gif-events)               | \*        | \*                 | see below                                                                                             |
 
 ```typescript
@@ -160,17 +163,18 @@ If you want controls for the video player, use the `controls` property.
 
 _Video props_
 
-| _prop_             | _type_                     | _default_ | _description_                                    |
-| ------------------ | -------------------------- | --------- | ------------------------------------------------ |
-| gif                | `IGif`                     | undefined | The gif to display that contains video data      |
-| width              | `number`                   | undefined | The width of the video                           |
-| height             | `number`                   | undefined | The height of the video                          |
-| controls           | `boolean`                  | undefined | Show transport controls                          |
-| hideProgressBar    | `boolean`                  | undefined | if controls is true, hides progress bar          |
-| hideMute           | `boolean`                  | undefined | if controls is true, hides the mute button       |
-| hidePlayPause      | `boolean`                  | undefined | if controls is true, hides the play/pause button |
-| persistentControls | `boolean`                  | undefined | don't hide controls when hovering away           |
-| onUserMuted        | `(muted: boolean) => void` | undefined | fired when the user toggles the mute state       |
+| _prop_             | _type_                     | _default_ | _description_                                                            |
+| ------------------ | -------------------------- | --------- | ------------------------------------------------------------------------ |
+| gif                | `IGif`                     | undefined | The gif to display that contains video data                              |
+| width              | `number`                   | undefined | The width of the video                                                   |
+| height             | `number`                   | undefined | The height of the video                                                  |
+| controls           | `boolean`                  | undefined | Show transport controls                                                  |
+| hideProgressBar    | `boolean`                  | undefined | if controls is true, hides progress bar                                  |
+| hideMute           | `boolean`                  | undefined | if controls is true, hides the mute button                               |
+| hidePlayPause      | `boolean`                  | undefined | if controls is true, hides the play/pause button                         |
+| persistentControls | `boolean`                  | undefined | don't hide controls when hovering away                                   |
+| onUserMuted        | `(muted: boolean) => void` | undefined | fired when the user toggles the mute state                               |
+| optInToTelemetry   | `boolean`                  | false     | Opt-in to sending telemetry events to Giphy on certain user interactions |
 
 ```typescript
 import { renderVideo } from '@giphy/js-components'
@@ -206,4 +210,4 @@ If a GIF has an associated user, an overlay with their avatar and display name w
 
 ```
 
-To stop fonts from loading set the environment variable `GIPHY_SDK_NO_FONTS=true`, this is not recommended as it could cause inconsistencies in the ui components 
+To stop fonts from loading set the environment variable `GIPHY_SDK_NO_FONTS=true`, this is not recommended as it could cause inconsistencies in the ui components

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,7 +4,8 @@
         "types": "tsc ./src/index.tsx -d --emitDeclarationOnly -declarationDir ./dist",
         "dev": "parcel public/test.html",
         "build": "tsc",
-        "prepublish": "npm run clean && tsc"
+        "prepublish": "npm run clean && tsc",
+        "test": "tsc --noEmit"
     },
     "devDependencies": {
         "@types/bricks.js": "^1.8.1",

--- a/packages/components/src/components/carousel.tsx
+++ b/packages/components/src/components/carousel.tsx
@@ -47,6 +47,8 @@ type Props = {
     noLink?: boolean
     tabIndex?: number
     borderRadius?: number
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
@@ -121,6 +123,7 @@ class Carousel extends Component<Props, State> {
             noLink,
             tabIndex = 0,
             borderRadius,
+            optInToTelemetry = false,
         }: Props,
         { gifs }: State
     ) {
@@ -155,6 +158,7 @@ class Carousel extends Component<Props, State> {
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
                                 borderRadius={borderRadius}
+                                optInToTelemetry={optInToTelemetry}
                             />
                         )
                     })}

--- a/packages/components/src/components/gif.tsx
+++ b/packages/components/src/components/gif.tsx
@@ -67,6 +67,8 @@ type GifProps = {
     noLink?: boolean
     borderRadius?: number
     tabIndex?: number
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 }
 
 export type Props = GifProps & EventProps
@@ -91,6 +93,7 @@ const Gif = ({
     noLink = false,
     borderRadius = 4,
     tabIndex,
+    optInToTelemetry = false,
 }: Props) => {
     // only fire seen once per gif id
     const [hasFiredSeen, setHasFiredSeen] = useState(false)
@@ -118,9 +121,11 @@ const Gif = ({
     const onMouseOver = (e: Event) => {
         clearTimeout(hoverTimeout.current!)
         setHovered(true)
-        hoverTimeout.current = window.setTimeout(() => {
-            pingback.onGifHover(gif, user?.id, e.target as HTMLElement, attributes)
-        }, hoverTimeoutDelay)
+        if (optInToTelemetry) {
+            hoverTimeout.current = window.setTimeout(() => {
+                pingback.onGifHover(gif, user?.id, e.target as HTMLElement, attributes)
+            }, hoverTimeoutDelay)
+        }
     }
 
     const onMouseLeave = () => {
@@ -129,8 +134,10 @@ const Gif = ({
     }
 
     const onClick = (e: Event) => {
-        // fire pingback
-        pingback.onGifClick(gif, user?.id, e.target as HTMLElement, attributes)
+        if (optInToTelemetry) {
+            // fire pingback
+            pingback.onGifClick(gif, user?.id, e.target as HTMLElement, attributes)
+        }
         onGifClick(gif, e)
     }
 
@@ -143,8 +150,10 @@ const Gif = ({
         // flag so we don't observe any more
         setHasFiredSeen(true)
         Logger.debug(`GIF ${gif.id} seen. ${gif.title}`)
-        // fire pingback
-        pingback.onGifSeen(gif, user?.id, entry.boundingClientRect, attributes)
+        if (optInToTelemetry) {
+            // fire pingback
+            pingback.onGifSeen(gif, user?.id, entry.boundingClientRect, attributes)
+        }
         // fire custom onGifSeen
         onGifSeen?.(gif, entry.boundingClientRect)
         // disconnect

--- a/packages/components/src/components/grid.tsx
+++ b/packages/components/src/components/grid.tsx
@@ -28,6 +28,8 @@ type Props = {
     noLink?: boolean
     tabIndex?: number
     borderRadius?: number
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 } & EventProps
 const defaultProps = Object.freeze({ gutter: 6, user: {} })
 
@@ -158,6 +160,7 @@ class Grid extends Component<Props, State> {
             noLink,
             tabIndex = 0,
             borderRadius,
+            optInToTelemetry = false,
         }: Props,
         { gifWidth, gifs, isError, isDoneFetching }: State
     ) {
@@ -183,6 +186,7 @@ class Grid extends Component<Props, State> {
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
                                 borderRadius={borderRadius}
+                                optInToTelemetry={optInToTelemetry}
                             />
                         ))}
                         {!showLoader && gifs.length === 0 && noResultsMessage}

--- a/packages/components/src/components/video/video.tsx
+++ b/packages/components/src/components/video/video.tsx
@@ -38,6 +38,8 @@ type Props = {
     height?: number
     volume?: number
     className?: string
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 }
 const Video = ({
     muted,
@@ -59,6 +61,7 @@ const Video = ({
     height: height_,
     volume = 0.7,
     className,
+    optInToTelemetry = false,
 }: Props) => {
     const height = height_ || getGifHeight(gif, width)
 
@@ -123,12 +126,12 @@ const Video = ({
         onStateChange?.('playing')
         if (!hasPlayingFired.current) {
             hasPlayingFired.current = true
-            if (gif.analytics_response_payload) {
+            if (optInToTelemetry && gif.analytics_response_payload) {
                 pingback({ actionType: 'START', analyticsResponsePayload: gif.analytics_response_payload })
             }
             onFirstPlay?.(Date.now() - mountTime.current)
         }
-    }, [onFirstPlay, onStateChange])
+    }, [onFirstPlay, onStateChange, optInToTelemetry])
     const _onPaused = useCallback(() => onStateChange?.('paused'), [onStateChange])
     const _onTimeUpdate = useCallback(() => {
         const el = videoEl.current

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -43,6 +43,7 @@ To try out it out before integrating, click on the code sandbox below. You may h
 | noResultsMessage                        | `string or JSX.Element`                  | undefined | Customize the "No results" message                                                                      |
 | loader                                  | `ElementType`                            | undefined | Customize the loader, the default is the GIPHY brand loader                                             |
 | noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick`   |
+| optInToTelemetry                        | `boolean`                                | false     | Opt-in to sending telemetry events to Giphy on certain user interactions                                |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                                                       |
 | [loaderConfig](#loader-config)          | `IntersectionObserverInit`               | undefined | Enables configuring the loader to fetch sooner than when just onscreen, allowing for smoother scrolling |
 | [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                               |
@@ -82,6 +83,7 @@ See this [codesandbox](https://codesandbox.io/s/giphy-web-sdk-ssr-with-nextjs-ir
 | borderRadius                            | `number`                                 | 4         | a border radius applied to Gif Components making the corners rounded                                                        |
 | noResultsMessage                        | `string or JSX.Element`                  | undefined | Customize the "No results" message                                                                                          |
 | noLink                                  | `boolean`                                | false     | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick`                       |
+| optInToTelemetry                        | `boolean`                                | false     | Opt-in to sending telemetry events to Giphy on certain user interactions                                                    |
 | [hideAttribution](#attribution-overlay) | `boolean`                                | false     | Hide the user attribution that appears over a GIF                                                                           |
 | [loaderConfig](#loader-config)          | `IntersectionObserverInit`               | undefined | Enables configuring the loader to fetch sooner than when just onscreen, allowing for smoother scrolling                     |
 | [Gif Events](#gif-events)               | \*                                       | \*        | see below                                                                                                                   |
@@ -118,8 +120,9 @@ _Gif props_
 | width                                   | `number`                                   | undefined          | The width of the gif                                                                                  |
 | borderRadius                            | `number`                                   | 4                  | a border radius making the corners rounded                                                            |
 | backgroundColor                         | `string`                                   | random giphy color | The background of the gif before it loads                                                             |
-| [hideAttribution](#attribution-overlay) | `boolean`                                  | false              | Hide the user attribution that appears over a GIF                                                     |
 | noLink                                  | `boolean`                                  | false              | Use a `div` instead of an `a` tag for the Gif component, user defines functionality with `onGifClick` |
+| optInToTelemetry                        | `boolean`                                  | false              | Opt-in to sending telemetry events to Giphy on certain user interactions                              |
+| [hideAttribution](#attribution-overlay) | `boolean`                                  | false              | Hide the user attribution that appears over a GIF                                                     |
 | [overlay](#gif-overlay)                 | `(props: GifOverlayProps):ReactType => {}` | undefined          | see below                                                                                             |
 | [Gif Events](#gif-events)               | \*                                         | \*                 | see below                                                                                             |
 
@@ -244,19 +247,20 @@ Here are the components in action in our [storybook](https://giphy.github.io/gip
 
 _Video props_
 
-| _prop_             | _type_                     | _default_ | _description_                                    |
-| ------------------ | -------------------------- | --------- | ------------------------------------------------ |
-| gif                | `IGif`                     | undefined | The gif to display that contains video data      |
-| width              | `number`                   | undefined | The width of the video                           |
-| height             | `number`                   | undefined | The height of the video                          |
-| controls           | `boolean`                  | undefined | Show transport controls                          |
-| hideProgressBar    | `boolean`                  | undefined | if controls is true, hides progress bar          |
-| hideMute           | `boolean`                  | undefined | if controls is true, hides the mute button       |
-| hidePlayPause      | `boolean`                  | undefined | if controls is true, hides the play/pause button |
-| persistentControls | `boolean`                  | undefined | don't hide controls when hovering away           |
-| ccEnabled          | `boolean`                  | false     | if true, show captions                           |
-| ccLanguage         | `string`                   | 'en'      | the closed caption language                      |
-| onUserMuted        | `(muted: boolean) => void` | undefined | fired when the user toggles the mute state       |
+| _prop_             | _type_                     | _default_ | _description_                                                            |
+| ------------------ | -------------------------- | --------- | ------------------------------------------------------------------------ |
+| gif                | `IGif`                     | undefined | The gif to display that contains video data                              |
+| width              | `number`                   | undefined | The width of the video                                                   |
+| height             | `number`                   | undefined | The height of the video                                                  |
+| controls           | `boolean`                  | undefined | Show transport controls                                                  |
+| hideProgressBar    | `boolean`                  | undefined | if controls is true, hides progress bar                                  |
+| hideMute           | `boolean`                  | undefined | if controls is true, hides the mute button                               |
+| hidePlayPause      | `boolean`                  | undefined | if controls is true, hides the play/pause button                         |
+| persistentControls | `boolean`                  | undefined | don't hide controls when hovering away                                   |
+| ccEnabled          | `boolean`                  | false     | if true, show captions                                                   |
+| ccLanguage         | `string`                   | 'en'      | the closed caption language                                              |
+| onUserMuted        | `(muted: boolean) => void` | undefined | fired when the user toggles the mute state                               |
+| optInToTelemetry   | `boolean`                  | false     | Opt-in to sending telemetry events to Giphy on certain user interactions |
 
 ```tsx
 import { Video } from '@giphy/react-components'

--- a/packages/react-components/cypress/stories/gif.spec.tsx
+++ b/packages/react-components/cypress/stories/gif.spec.tsx
@@ -4,13 +4,15 @@ import { composeStories } from '@storybook/testing-react'
 import * as stories from '../../stories/gif.stories'
 import { storiesCompositionToList } from '../utils/storybook'
 import {
-    setupGifTestUtils,
-    GifTestUtilsContext,
-    checkGifSeen,
-    checkGifMouseEvents,
-    checkGifKeyboardEvents,
     checkGifIsVisible,
+    checkGifKeyboardEvents,
+    checkGifMouseEvents,
+    checkGifSeen,
+    GifTestUtilsContext,
+    performAllGifTelemetryEvents,
+    setupGifTestUtils,
 } from '../utils/gif-test-utils'
+import { checkNoTelemetryHappens, checkUsualTelemetryHappens, interceptPingbacks } from '../utils/pingback-utils'
 
 const storiesGifIds = {
     Gif: 'ZEU9ryYGZzttn0Cva7',
@@ -38,6 +40,41 @@ describe('Gif', () => {
             checkGifSeen(gifTestUtilsCtx, options)
             checkGifMouseEvents(gifTestUtilsCtx, options)
             checkGifKeyboardEvents(gifTestUtilsCtx, options)
+        })
+    })
+
+    describe('telemetry tests', () => {
+        let gifTestUtilsCtx: GifTestUtilsContext
+
+        before(() => {
+            gifTestUtilsCtx = setupGifTestUtils('my-id')
+        })
+
+        for (const { Component, title } of [
+            {
+                title: 'should send no telemetry if user has not specified the opt-in prop',
+                Component: (events: typeof gifTestUtilsCtx['events']) => <stories.Gif {...events} />,
+            },
+            {
+                title: 'should send no telemetry if user has explicitly opted out',
+                Component: (events: typeof gifTestUtilsCtx['events']) => (
+                    <stories.Gif {...events} optInToTelemetry={false} />
+                ),
+            },
+        ]) {
+            it(title, () => {
+                interceptPingbacks()
+                cy.mount(<Component {...gifTestUtilsCtx.events} />)
+                performAllGifTelemetryEvents()
+                checkNoTelemetryHappens()
+            })
+        }
+
+        it('should send usual telemetry if user has explicitly opted in', () => {
+            interceptPingbacks()
+            cy.mount(<stories.Gif {...gifTestUtilsCtx.events} optInToTelemetry={true} />)
+            performAllGifTelemetryEvents()
+            checkUsualTelemetryHappens()
         })
     })
 })

--- a/packages/react-components/cypress/utils/gif-test-utils.ts
+++ b/packages/react-components/cypress/utils/gif-test-utils.ts
@@ -122,3 +122,12 @@ export function checkGifMouseEvents(
         cy.percySnapshot(`${options.snapshotNamePrefix}: onRightClick`)
     }
 }
+
+export const performAllGifTelemetryEvents = () => {
+    cy.get(`[data-cy-root] .${Gif.className}`)
+        .click()
+        .trigger('mouseover')
+        // hover timeout delay
+        .wait(200)
+        .type('{enter}')
+}

--- a/packages/react-components/cypress/utils/gif-test-utils.ts
+++ b/packages/react-components/cypress/utils/gif-test-utils.ts
@@ -123,9 +123,9 @@ export function checkGifMouseEvents(
     }
 }
 
-export const performAllGifTelemetryEvents = () => {
-    cy.get(`[data-cy-root] .${Gif.className}`)
-        .click()
+export const performAllGifTelemetryEvents = (gifId?: string) => {
+    const gif = gifId ? getGifRoot(gifId) : cy.get(`[data-cy-root] .${Gif.className}`)
+    gif.click()
         .trigger('mouseover')
         // hover timeout delay
         .wait(200)

--- a/packages/react-components/cypress/utils/pingback-utils.ts
+++ b/packages/react-components/cypress/utils/pingback-utils.ts
@@ -1,0 +1,21 @@
+const timeout = 1_000
+
+export const interceptPingbacks = () => {
+    cy.intercept(`https://pingback.giphy.com/**`).as('pingback')
+}
+
+export const checkNoTelemetryHappens = () => {
+    Cypress.once('fail', (err) => {
+        if (!err.toString().includes(`CypressError: Timed out retrying after ${timeout}ms`)) {
+            throw err
+        }
+    })
+
+    cy.wait('@pingback', { requestTimeout: timeout }).then((interception) => {
+        expect(interception).to.not.exist
+    })
+}
+
+export const checkUsualTelemetryHappens = () => {
+    cy.wait('@pingback', { requestTimeout: timeout })
+}

--- a/packages/react-components/cypress/utils/video-test-utils.ts
+++ b/packages/react-components/cypress/utils/video-test-utils.ts
@@ -121,3 +121,7 @@ export function checkVideoEvents(ctx: VideoTestUtilsContext) {
             }
         })
 }
+
+export const performAllVideoTelemetryEvents = (videoId: string) => {
+    getVideoElement(videoId).trigger('play').trigger('pause')
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -10,7 +10,8 @@
         "cy:run": "percy exec -- cypress run --component -b chrome",
         "cy:open": "cypress open --component -b chrome",
         "cy:verify": "cypress verify",
-        "cy:info": "cypress info"
+        "cy:info": "cypress info",
+        "test": "tsc --noEmit && npm run cy:run"
     },
     "devDependencies": {
         "@babel/core": "^7.18.6",

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -63,6 +63,8 @@ type Props = {
     borderRadius?: number
     tabIndex?: number
     loaderConfig?: IntersectionObserverInit
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 } & EventProps
 
 const defaultProps = Object.freeze({ gutter: 6, user: {}, initialGifs: [] })
@@ -143,6 +145,7 @@ class Carousel extends PureComponent<Props, State> {
             borderRadius,
             tabIndex = 0,
             loaderConfig,
+            optInToTelemetry,
         } = this.props
         const { gifs, isDoneFetching } = this.state
         const showLoader = !isDoneFetching
@@ -170,6 +173,7 @@ class Carousel extends PureComponent<Props, State> {
                                 noLink={noLink}
                                 borderRadius={borderRadius}
                                 backgroundColor={backgroundColor}
+                                optInToTelemetry={optInToTelemetry}
                             />
                         )
                     })}

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -79,6 +79,8 @@ type GifProps = {
     borderRadius?: number
     tabIndex?: number
     style?: any
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 }
 
 type Props = GifProps & EventProps
@@ -108,6 +110,7 @@ const Gif = ({
     borderRadius = 4,
     style,
     tabIndex,
+    optInToTelemetry = false,
 }: Props) => {
     // only fire seen once per gif id
     const [hasFiredSeen, setHasFiredSeen] = useState(false)
@@ -145,9 +148,11 @@ const Gif = ({
         clearTimeout(hoverTimeout.current!)
         e.persist()
         setHovered(true)
-        hoverTimeout.current = window.setTimeout(() => {
-            pingback.onGifHover(gif, user?.id, e.target as HTMLElement, attributes)
-        }, hoverTimeoutDelay)
+        if (optInToTelemetry) {
+            hoverTimeout.current = window.setTimeout(() => {
+                pingback.onGifHover(gif, user?.id, e.target as HTMLElement, attributes)
+            }, hoverTimeoutDelay)
+        }
     }
 
     const onMouseLeave = () => {
@@ -156,8 +161,10 @@ const Gif = ({
     }
 
     const onClick = (e: SyntheticEvent<HTMLElement, Event>) => {
-        // fire pingback
-        pingback.onGifClick(gif, user?.id, e.target as HTMLElement, attributes)
+        if (optInToTelemetry) {
+            // fire pingback
+            pingback.onGifClick(gif, user?.id, e.target as HTMLElement, attributes)
+        }
         onGifClick(gif, e)
     }
 
@@ -170,8 +177,10 @@ const Gif = ({
         // flag so we don't observe any more
         setHasFiredSeen(true)
         Logger.debug(`GIF ${gif.id} seen. ${gif.title}`)
-        // fire pingback
-        pingback.onGifSeen(gif, user?.id, entry.boundingClientRect, attributes)
+        if (optInToTelemetry) {
+            // fire pingback
+            pingback.onGifSeen(gif, user?.id, entry.boundingClientRect, attributes)
+        }
         // fire custom onGifSeen
         onGifSeen?.(gif, entry.boundingClientRect)
         // disconnect

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -34,6 +34,8 @@ type Props = {
     tabIndex?: number
     loaderConfig?: IntersectionObserverInit
     loader?: ElementType
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 } & EventProps
 
 const Loader = styled.div<{ isFirstLoad: boolean }>`
@@ -154,6 +156,7 @@ class Grid extends PureComponent<Props, State> {
             tabIndex = 0,
             layoutType = 'GRID',
             loader: LoaderVisual = DotsLoader,
+            optInToTelemetry,
         } = this.props
         const { gifWidth, gifs, isError, isDoneFetching } = this.state
         const showLoader = !isDoneFetching
@@ -188,6 +191,7 @@ class Grid extends PureComponent<Props, State> {
                                 hideAttribution={hideAttribution}
                                 noLink={noLink}
                                 borderRadius={borderRadius}
+                                optInToTelemetry={optInToTelemetry}
                             />
                         ))}
                     </MasonryGrid>

--- a/packages/react-components/src/components/video/video.tsx
+++ b/packages/react-components/src/components/video/video.tsx
@@ -42,6 +42,8 @@ type Props = {
     height?: number
     volume?: number
     className?: string
+    // Enables telemetry; opt-in
+    optInToTelemetry?: boolean
 }
 const Video = ({
     muted,
@@ -65,6 +67,7 @@ const Video = ({
     height: height_,
     volume = 0.7,
     className = videoClassName,
+    optInToTelemetry = false,
 }: Props) => {
     const height = height_ || getGifHeight(gif, width)
 
@@ -129,12 +132,12 @@ const Video = ({
         onStateChange?.('playing')
         if (!hasPlayingFired.current) {
             hasPlayingFired.current = true
-            if (gif.analytics_response_payload) {
+            if (optInToTelemetry && gif.analytics_response_payload) {
                 pingback({ actionType: 'START', analyticsResponsePayload: gif.analytics_response_payload })
             }
             onFirstPlay?.(Date.now() - mountTime.current)
         }
-    }, [onFirstPlay, onStateChange, gif])
+    }, [onFirstPlay, onStateChange, gif, optInToTelemetry])
     const _onPaused = useCallback(() => onStateChange?.('paused'), [onStateChange])
     const _onTimeUpdate = useCallback(() => {
         const el = videoEl.current

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,8 @@
         "clean": "rm -rf ./dist",
         "dev": "tsc --watch",
         "build": "tsc -d --emitDeclarationOnly -declarationDir ./dist",
-        "prepublish": "npm run clean && tsc -d --emitDeclarationOnly -declarationDir ./dist"
+        "prepublish": "npm run clean && tsc -d --emitDeclarationOnly -declarationDir ./dist",
+        "test": "tsc --noEmit"
     },
     "name": "@giphy/js-types",
     "homepage": "https://github.com/Giphy/giphy-js/tree/master/packages/types",


### PR DESCRIPTION
This PR adds a `optInToTelemetry` prop to all components that can cause any pingback events. By default, it is set to false, creating an opt-in behavior. Pingback events are only sent when users explicitly opt-in.

I added e2e tests for this behavior for the react-components. Since the normal components didn't seem to have a pre-existing test setup, I didn't add any here. Of course, I also added documentation for the new property.

Also, in an effort to follow the boyscout rule, I added `npm test` scripts to packages that didn't have it yet so `npm test` can now be executed globally. Let me know if you would prefer me to extract those changes into a separate PR.

Fixes #291 