### PR TITLE
feat/rating-param-changes

### DIFF
--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -122,13 +122,13 @@ export class GiphyFetch {
      * @param options: SearchOptions
      * @returns {Promise<GifsResult>}
      **/
-    search(term: string, options: SearchOptions = {rating: 'pg-13'}): Promise<GifsResult> {
+    search(term: string, options: SearchOptions = {}): Promise<GifsResult> {
         const q = options.channel ? `@${options.channel} ${term}` : term
         let excludeDynamicResults
         if (options.type === 'text') {
             excludeDynamicResults = true
         }
-        const qsParams = this.getQS({ ...options, q, excludeDynamicResults })
+        const qsParams = this.getQS({ ...options, q, excludeDynamicResults, rating: 'pg-13' })
         return request(`${getType(options)}/search?${qsParams}`, { normalizer: normalizeGifs }) as Promise<GifsResult>
     }
 
@@ -148,8 +148,8 @@ export class GiphyFetch {
      * @param {TrendingOptions} options
      * @returns {Promise<GifsResult>}
      */
-    trending(options: TrendingOptions = {rating: 'pg-13'}): Promise<GifsResult> {
-        return request(`${getType(options)}/trending?${this.getQS(options)}`, {
+    trending(options: TrendingOptions = {}): Promise<GifsResult> {
+        return request(`${getType(options)}/trending?${this.getQS({rating: 'pg-13', ...options})}`, {
             normalizer: normalizeGifs,
         }) as Promise<GifsResult>
     }
@@ -160,7 +160,7 @@ export class GiphyFetch {
      * @returns {Promise<GifResult>}
      **/
     random(options?: RandomOptions): Promise<GifResult> {
-        return request(`${getType(options)}/random?${this.getQS(options)}`, {
+        return request(`${getType(options)}/random?${this.getQS({rating: 'pg-13', ...options})}`, {
             noCache: true,
             normalizer: normalizeGif,
         }) as Promise<GifResult>
@@ -174,7 +174,7 @@ export class GiphyFetch {
      **/
     related(id: string, options?: RelatedOptions): Promise<GifsResult> {
         return request(
-            `${options?.type === 'stickers' ? 'stickers' : 'gifs'}/related?${this.getQS({ gif_id: id, ...options })}`,
+            `${options?.type === 'stickers' ? 'stickers' : 'gifs'}/related?${this.getQS({ gif_id: id, rating: 'pg-13', ...options })}`,
             { normalizer: normalizeGifs }
         ) as Promise<GifsResult>
     }
@@ -185,8 +185,8 @@ export class GiphyFetch {
      * @param options: SearchOptions
      * @returns {Promise<ChannelsResult>}
      **/
-    channels(term: string, options: SearchOptions = {rating: 'pg-13'}): Promise<ChannelsResult> {
-        return request(`channels/search?${this.getQS({ q: term, ...options })}`) as Promise<ChannelsResult>
+    channels(term: string, options: SearchOptions = {}): Promise<ChannelsResult> {
+        return request(`channels/search?${this.getQS({ q: term, rating: 'pg-13', ...options })}`) as Promise<ChannelsResult>
     }
 }
 export default GiphyFetch

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -149,7 +149,7 @@ export class GiphyFetch {
      * @returns {Promise<GifsResult>}
      */
     trending(options: TrendingOptions = {}): Promise<GifsResult> {
-        return request(`${getType(options)}/trending?${this.getQS({rating: 'pg-13', ...options})}`, {
+        return request(`${getType(options)}/trending?${this.getQS({ rating: 'pg-13', ...options })}`, {
             normalizer: normalizeGifs,
         }) as Promise<GifsResult>
     }
@@ -160,7 +160,7 @@ export class GiphyFetch {
      * @returns {Promise<GifResult>}
      **/
     random(options?: RandomOptions): Promise<GifResult> {
-        return request(`${getType(options)}/random?${this.getQS({rating: 'pg-13', ...options})}`, {
+        return request(`${getType(options)}/random?${this.getQS({ rating: 'pg-13', ...options })}`, {
             noCache: true,
             normalizer: normalizeGif,
         }) as Promise<GifResult>
@@ -174,7 +174,11 @@ export class GiphyFetch {
      **/
     related(id: string, options?: RelatedOptions): Promise<GifsResult> {
         return request(
-            `${options?.type === 'stickers' ? 'stickers' : 'gifs'}/related?${this.getQS({ gif_id: id, rating: 'pg-13', ...options })}`,
+            `${options?.type === 'stickers' ? 'stickers' : 'gifs'}/related?${this.getQS({
+                gif_id: id,
+                rating: 'pg-13',
+                ...options,
+            })}`,
             { normalizer: normalizeGifs }
         ) as Promise<GifsResult>
     }
@@ -186,7 +190,9 @@ export class GiphyFetch {
      * @returns {Promise<ChannelsResult>}
      **/
     channels(term: string, options: SearchOptions = {}): Promise<ChannelsResult> {
-        return request(`channels/search?${this.getQS({ q: term, rating: 'pg-13', ...options })}`) as Promise<ChannelsResult>
+        return request(
+            `channels/search?${this.getQS({ q: term, rating: 'pg-13', ...options })}`
+        ) as Promise<ChannelsResult>
     }
 }
 export default GiphyFetch

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -122,7 +122,7 @@ export class GiphyFetch {
      * @param options: SearchOptions
      * @returns {Promise<GifsResult>}
      **/
-    search(term: string, options: SearchOptions = {}): Promise<GifsResult> {
+    search(term: string, options: SearchOptions = {rating: 'pg-13'}): Promise<GifsResult> {
         const q = options.channel ? `@${options.channel} ${term}` : term
         let excludeDynamicResults
         if (options.type === 'text') {
@@ -148,7 +148,7 @@ export class GiphyFetch {
      * @param {TrendingOptions} options
      * @returns {Promise<GifsResult>}
      */
-    trending(options: TrendingOptions = {}): Promise<GifsResult> {
+    trending(options: TrendingOptions = {rating: 'pg-13'}): Promise<GifsResult> {
         return request(`${getType(options)}/trending?${this.getQS(options)}`, {
             normalizer: normalizeGifs,
         }) as Promise<GifsResult>
@@ -185,7 +185,7 @@ export class GiphyFetch {
      * @param options: SearchOptions
      * @returns {Promise<ChannelsResult>}
      **/
-    channels(term: string, options: SearchOptions = {}): Promise<ChannelsResult> {
+    channels(term: string, options: SearchOptions = {rating: 'pg-13'}): Promise<ChannelsResult> {
         return request(`channels/search?${this.getQS({ q: term, ...options })}`) as Promise<ChannelsResult>
     }
 }

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -5,7 +5,7 @@ export type MediaType = 'stickers' | 'gifs' | 'text' | 'videos'
 /**
  * Filters results by specified rating.
  */
-type Rating = 'pg' | 'g' | 'y' | 'pg-13' | 'r'
+export type Rating = 'pg' | 'g' | 'y' | 'pg-13' | 'r'
 /**
  * Sorting options
  */
@@ -25,6 +25,7 @@ export interface CategoriesOptions extends PaginationOptions {}
 export interface SubcategoriesOptions extends PaginationOptions {}
 export interface RelatedOptions extends PaginationOptions {
     type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
+    rating?: Rating
 }
 
 export interface TrendingOptions extends PaginationOptions, TypeOption {

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -25,22 +25,22 @@ export interface CategoriesOptions extends PaginationOptions {}
 export interface SubcategoriesOptions extends PaginationOptions {}
 export interface RelatedOptions extends PaginationOptions {
     type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
-    rating: Rating
+    rating?: Rating
 }
 
 export interface TrendingOptions extends PaginationOptions, TypeOption {
-    rating: Rating
+    rating?: Rating
 }
 
 export interface RandomOptions extends PaginationOptions {
     type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
     tag?: string
-    rating: Rating
+    rating?: Rating
 }
 
 export interface SearchOptions extends PaginationOptions, TypeOption {
     sort?: SortTypes
-    rating: Rating
+    rating?: Rating
     lang?: string
     channel?: string
     explore?: boolean

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -25,22 +25,22 @@ export interface CategoriesOptions extends PaginationOptions {}
 export interface SubcategoriesOptions extends PaginationOptions {}
 export interface RelatedOptions extends PaginationOptions {
     type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
-    rating?: Rating
+    rating: Rating
 }
 
 export interface TrendingOptions extends PaginationOptions, TypeOption {
-    rating?: Rating
+    rating: Rating
 }
 
 export interface RandomOptions extends PaginationOptions {
     type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
     tag?: string
-    rating?: Rating
+    rating: Rating
 }
 
 export interface SearchOptions extends PaginationOptions, TypeOption {
     sort?: SortTypes
-    rating?: Rating
+    rating: Rating
     lang?: string
     channel?: string
     explore?: boolean


### PR DESCRIPTION
* Adding rating param to `random` fetch and exporting `Rating` type to stay consistent with use of `MediaType`
* We will be removing the `force_max_rating_pg-13` in the ACL, web-app front-end needs to pass a rating param in api calls

https://giphypedia.atlassian.net/browse/CXP-1895