### PR TITLE
Fix typo in component name

### DIFF
--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -166,7 +166,7 @@ const Components = () => {
     const { fetchGifs, searchKey } = useContext(SearchContext)
     return (
         <>
-            <SearchBarComponent />
+            <SearchBar />
             <SuggestionBar />
             {/** 
                 key will recreate the component, 


### PR DESCRIPTION
The component name was misspelled, corrected it to match the correct spelling.