### PR TITLE
react-components: add percentWidth prop for Gif. fetch-api: add type videos to related fetch

### DIFF
--- a/.changeset/angry-lamps-dream.md
+++ b/.changeset/angry-lamps-dream.md
@@ -1,0 +1,8 @@
+---
+'@giphy/react-components': minor
+'@giphy/js-fetch-api': minor
+---
+
+react-components: percentWidth prop on gif allows you to display a Gif component using a css percentage value
+
+fetch-api: add type videos to related end point

--- a/.changeset/twenty-rules-relax.md
+++ b/.changeset/twenty-rules-relax.md
@@ -1,5 +1,0 @@
----
-'@giphy/react-components': patch
----
-
-percentWidth prop on gif allows you to display a Gif component using a css percentage value

--- a/.changeset/twenty-rules-relax.md
+++ b/.changeset/twenty-rules-relax.md
@@ -1,0 +1,5 @@
+---
+'@giphy/react-components': patch
+---
+
+percentWidth prop on gif allows you to display a Gif component using a css percentage value

--- a/packages/fetch-api/public/index.tsx
+++ b/packages/fetch-api/public/index.tsx
@@ -36,10 +36,19 @@ const gifByCategory = async () => {
 }
 const related = async () => {
     try {
-        const result = await gf.related('3oEjHGr1Fhz0kyv8Ig')
+        const result = await gf.related('3oEjHGr1Fhz0kyv8Ig', { limit: 4 })
         console.log('related', result)
     } catch (error) {
         console.error('related', error)
+    }
+}
+
+const relatedClips = async () => {
+    try {
+        const result = await gf.related('W2nuhlWbyVmV73jIsc', { type: 'videos' })
+        console.log('related videos', result)
+    } catch (error) {
+        console.error('related videos', error)
     }
 }
 
@@ -145,3 +154,4 @@ text()
 textTrending()
 animate()
 searchVideos()
+relatedClips()

--- a/packages/fetch-api/src/api.ts
+++ b/packages/fetch-api/src/api.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-dupe-class-members */
+import { GifID } from '@giphy/js-types'
 import { getPingbackId } from '@giphy/js-util'
 import qs from 'qs'
 import { normalizeGif, normalizeGifs } from './normalize/gif'
@@ -14,7 +15,6 @@ import {
     TypeOption,
 } from './option-types'
 import request from './request'
-import { GifID } from '@giphy/js-types'
 import { CategoriesResult, ChannelsResult, GifResult, GifsResult, NonPaginatedGifsResult } from './result-types'
 
 const getType = (options?: TypeOption): MediaType => (options && options.type ? options.type : 'gifs')
@@ -172,9 +172,10 @@ export class GiphyFetch {
      * @param {SubcategoriesOptions} options
      * @returns {Promise<GifsResult>}
      **/
-    related(id: string, options?: RelatedOptions): Promise<GifsResult> {
+    related(id: string, options: RelatedOptions = {}): Promise<GifsResult> {
+        const { type = 'gifs' } = options
         return request(
-            `${options?.type === 'stickers' ? 'stickers' : 'gifs'}/related?${this.getQS({
+            `${type}/related?${this.getQS({
                 gif_id: id,
                 rating: 'pg-13',
                 ...options,

--- a/packages/fetch-api/src/option-types.ts
+++ b/packages/fetch-api/src/option-types.ts
@@ -24,7 +24,7 @@ export interface PaginationOptions {
 export interface CategoriesOptions extends PaginationOptions {}
 export interface SubcategoriesOptions extends PaginationOptions {}
 export interface RelatedOptions extends PaginationOptions {
-    type?: 'gifs' | 'stickers' // no 'text' support, overrride MediaType
+    type?: 'gifs' | 'stickers' | 'videos' // no 'text' support, overrride MediaType
     rating?: Rating
 }
 

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -2,32 +2,17 @@ import { giphyBlue, giphyGreen, giphyPurple, giphyRed, giphyYellow } from '@giph
 import { IGif, IUser, ImageAllTypes } from '@giphy/js-types'
 import { Logger, getAltText, getBestRendition, getGifHeight } from '@giphy/js-util'
 import 'intersection-observer'
-import React, {
-    ElementType,
-    HTMLAttributes,
-    HTMLProps,
-    ReactNode,
-    SyntheticEvent,
-    useContext,
-    useEffect,
-    useRef,
-    useState,
-} from 'react'
-import styled, { css } from 'styled-components'
+import React, { ElementType, ReactNode, SyntheticEvent, useContext, useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
 import * as pingback from '../util/pingback'
 import AttributionOverlay from './attribution/overlay'
 import VerifiedBadge from './attribution/verified-badge'
 import { PingbackContext } from './pingback-context-manager'
 import { GifOverlayProps } from './types'
 
-const GifContainer = styled.div<{ borderRadius?: number }>`
+const Container = styled.div`
+    position: relative;
     display: block;
-    ${(props) =>
-        props.borderRadius &&
-        css`
-            border-radius: ${props.borderRadius}px;
-            overflow: hidden;
-        `}
     img {
         display: block;
     }
@@ -45,11 +30,6 @@ export const GRID_COLORS = [giphyBlue, giphyGreen, giphyPurple, giphyRed, giphyY
 export const getColor = () => GRID_COLORS[Math.round(Math.random() * (GRID_COLORS.length - 1))]
 
 const hoverTimeoutDelay = 200
-
-type ContainerProps = HTMLProps<HTMLElement> & { href?: string; borderRadius: number }
-const Container = (props: ContainerProps) => (
-    <GifContainer as={props.href ? 'a' : 'div'} {...(props as HTMLAttributes<HTMLDivElement>)} />
-)
 
 export type EventProps = {
     // fired every time the gif is show
@@ -247,17 +227,21 @@ const Gif = ({
         (gif.is_sticker
             ? `url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADgAAAA4AQMAAACSSKldAAAABlBMVEUhIiIWFhYoSqvJAAAAGElEQVQY02MAAv7///8PWxqIPwDZw5UGABtgwz2xhFKxAAAAAElFTkSuQmCC') 0 0`
             : defaultBgColor.current)
+
+    const overflow = borderRadius ? 'hidden' : 'unset'
     return (
         <Container
+            as={noLink ? 'div' : 'a'}
             href={noLink ? undefined : gif.url}
             data-giphy-id={gif.id}
             data-giphy-is-sticker={gif.is_sticker}
             style={{
                 width,
                 height,
+                overflow,
+                borderRadius,
                 ...style,
             }}
-            borderRadius={borderRadius}
             className={[Gif.className, className].join(' ')}
             onMouseOver={onMouseOver}
             onMouseLeave={onMouseLeave}
@@ -265,33 +249,32 @@ const Gif = ({
             onContextMenu={(e: SyntheticEvent<HTMLElement, Event>) => onGifRightClick(gif, e)}
             onKeyPress={onKeyPress}
             tabIndex={tabIndex}
+            ref={container}
         >
-            <div style={{ position: 'relative' }} ref={container}>
-                <picture>
-                    <source
-                        type="image/webp"
-                        srcSet={shouldShowMedia ? rendition.webp : placeholder}
-                        suppressHydrationWarning
-                    />
-                    <img
-                        ref={image}
-                        suppressHydrationWarning
-                        className={[Gif.imgClassName, loadedClassname].join(' ')}
-                        src={shouldShowMedia ? rendition.url : placeholder}
-                        style={{ background }}
-                        width="100%"
-                        height="100%"
-                        alt={getAltText(gif)}
-                        onLoad={shouldShowMedia ? onImageLoad : () => {}}
-                    />
-                </picture>
-                {Overlay && (
-                    // only render the overlay on the client since it depends on shouldShowMedia
-                    <RenderOnClient>
-                        {shouldShowMedia && <Overlay gif={gif} isHovered={isHovered} width={width} height={height} />}
-                    </RenderOnClient>
-                )}
-            </div>
+            <picture>
+                <source
+                    type="image/webp"
+                    srcSet={shouldShowMedia ? rendition.webp : placeholder}
+                    suppressHydrationWarning
+                />
+                <img
+                    ref={image}
+                    suppressHydrationWarning
+                    className={[Gif.imgClassName, loadedClassname].join(' ')}
+                    src={shouldShowMedia ? rendition.url : placeholder}
+                    style={{ background }}
+                    width="100%"
+                    height="100%"
+                    alt={getAltText(gif)}
+                    onLoad={shouldShowMedia ? onImageLoad : () => {}}
+                />
+            </picture>
+            {Overlay && (
+                // only render the overlay on the client since it depends on shouldShowMedia
+                <RenderOnClient>
+                    {shouldShowMedia && <Overlay gif={gif} isHovered={isHovered} width={width} height={height} />}
+                </RenderOnClient>
+            )}
         </Container>
     )
 }

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -266,7 +266,7 @@ const Gif = ({
             onKeyPress={onKeyPress}
             tabIndex={tabIndex}
         >
-            <div style={{ width, height, position: 'relative' }} ref={container}>
+            <div style={{ position: 'relative' }} ref={container}>
                 <picture>
                     <source
                         type="image/webp"
@@ -279,8 +279,8 @@ const Gif = ({
                         className={[Gif.imgClassName, loadedClassname].join(' ')}
                         src={shouldShowMedia ? rendition.url : placeholder}
                         style={{ background }}
-                        width={width}
-                        height={height}
+                        width="100%"
+                        height="100%"
                         alt={getAltText(gif)}
                         onLoad={shouldShowMedia ? onImageLoad : () => {}}
                     />

--- a/packages/react-components/src/components/gif.tsx
+++ b/packages/react-components/src/components/gif.tsx
@@ -47,6 +47,7 @@ export type EventProps = {
 type GifProps = {
     gif: IGif
     width: number
+    percentWidth?: string
     height?: number
     backgroundColor?: string
     className?: string
@@ -79,6 +80,7 @@ const RenderOnClient = ({ children }: { children: ReactNode }) => {
 const Gif = ({
     gif,
     width,
+    percentWidth,
     height: forcedHeight,
     onGifRightClick = noop,
     className = '',
@@ -219,6 +221,11 @@ const Gif = ({
         }
     }, [])
     const height = forcedHeight || getGifHeight(gif, width)
+    let percentHeight: string | undefined
+    if (percentWidth) {
+        const ratio = Math.round((height / width) * 100)
+        percentHeight = `${ratio}%`
+    }
     const bestRendition = getBestRendition(gif.images, width, height)
     const rendition = gif.images[bestRendition.renditionName] as ImageAllTypes
     const background =
@@ -236,8 +243,8 @@ const Gif = ({
             data-giphy-id={gif.id}
             data-giphy-is-sticker={gif.is_sticker}
             style={{
-                width,
-                height,
+                width: percentWidth || width,
+                height: percentHeight || height,
                 overflow,
                 borderRadius,
                 ...style,

--- a/packages/react-components/stories/gif.stories.tsx
+++ b/packages/react-components/stories/gif.stories.tsx
@@ -88,7 +88,7 @@ export const GifWithVideoOverlayFillVideo: Story = {
     args: {
         id: '3BNRWBatePBETD7Bfg',
         height: 300,
-        overlay: (props: GifOverlayProps) => <VideoOverlay {...props} width={number('width', 500)} />,
+        overlay: (props: GifOverlayProps) => <VideoOverlay {...props} width={number('width', 300)} />,
     },
 }
 

--- a/packages/react-components/stories/gif.stories.tsx
+++ b/packages/react-components/stories/gif.stories.tsx
@@ -1,7 +1,6 @@
 // @ts-ignore TS2783
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { IGif } from '@giphy/js-types'
-import { getGifHeight } from '@giphy/js-util'
 import { action } from '@storybook/addon-actions'
 import { number } from '@storybook/addon-knobs'
 import { Meta, StoryObj } from '@storybook/react'
@@ -22,7 +21,7 @@ type GifDemoProps = Omit<GifComponentProps, 'gif'> & {
     scale: string
 }
 
-const GifDemo = ({ id, width, height, noLink, borderRadius, scale, overlay, ...other }: GifDemoProps) => {
+const GifDemo = ({ id, width, height, noLink, borderRadius, percentWidth, overlay, ...other }: GifDemoProps) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = useCallback(async () => {
@@ -40,7 +39,7 @@ const GifDemo = ({ id, width, height, noLink, borderRadius, scale, overlay, ...o
             tabIndex={1}
             borderRadius={borderRadius}
             gif={gif}
-            style={{ width: scale ? scale : width, height: scale ? getHeightPerc(gif, width) : height }}
+            percentWidth={percentWidth}
             width={width}
             height={height}
             noLink={noLink}
@@ -67,8 +66,8 @@ const meta: Meta<typeof GifDemo> = {
         noLink: {
             control: { type: 'boolean' },
         },
-        scale: {
-            control: { type: 'string' },
+        percentWidth: {
+            control: { type: 'text' },
         },
     },
     args: {
@@ -92,7 +91,7 @@ export const GifWithOverlay: Story = {
 
 export const GifThatStretches: Story = {
     args: {
-        scale: '50%',
+        percentWidth: '50%',
     },
 }
 
@@ -112,10 +111,4 @@ export const GifNoBorderRadius: Story = {
 
 export const Sticker: Story = {
     args: { id: 'l1J9FvenuBnI4GTeg' },
-}
-function getHeightPerc(gif: IGif | undefined, width: number) {
-    if (!gif) return '100%'
-    const gifHeight = getGifHeight(gif, width)
-    const heightPercentage = `${Math.round((gifHeight / width) * 100)}%`
-    return heightPercentage
 }

--- a/packages/react-components/stories/gif.stories.tsx
+++ b/packages/react-components/stories/gif.stories.tsx
@@ -1,6 +1,7 @@
 // @ts-ignore TS2783
 import { GiphyFetch } from '@giphy/js-fetch-api'
 import { IGif } from '@giphy/js-types'
+import { getGifHeight } from '@giphy/js-util'
 import { action } from '@storybook/addon-actions'
 import { number } from '@storybook/addon-knobs'
 import { Meta, StoryObj } from '@storybook/react'
@@ -18,9 +19,10 @@ type GifComponentProps = React.ComponentProps<typeof GifComponent>
 
 type GifDemoProps = Omit<GifComponentProps, 'gif'> & {
     id: string
+    scale: string
 }
 
-const GifDemo = ({ id, width, height, noLink, borderRadius, overlay, ...other }: GifDemoProps) => {
+const GifDemo = ({ id, width, height, noLink, borderRadius, scale, overlay, ...other }: GifDemoProps) => {
     const [gif, setGif] = useState<IGif>()
 
     const fetch = useCallback(async () => {
@@ -38,6 +40,7 @@ const GifDemo = ({ id, width, height, noLink, borderRadius, overlay, ...other }:
             tabIndex={1}
             borderRadius={borderRadius}
             gif={gif}
+            style={{ width: scale ? scale : width, height: scale ? getHeightPerc(gif, width) : height }}
             width={width}
             height={height}
             noLink={noLink}
@@ -64,6 +67,9 @@ const meta: Meta<typeof GifDemo> = {
         noLink: {
             control: { type: 'boolean' },
         },
+        scale: {
+            control: { type: 'string' },
+        },
     },
     args: {
         id: 'ZEU9ryYGZzttn0Cva7',
@@ -84,6 +90,12 @@ export const GifWithOverlay: Story = {
     },
 }
 
+export const GifThatStretches: Story = {
+    args: {
+        scale: '50%',
+    },
+}
+
 export const GifWithVideoOverlayFillVideo: Story = {
     args: {
         id: '3BNRWBatePBETD7Bfg',
@@ -100,4 +112,10 @@ export const GifNoBorderRadius: Story = {
 
 export const Sticker: Story = {
     args: { id: 'l1J9FvenuBnI4GTeg' },
+}
+function getHeightPerc(gif: IGif | undefined, width: number) {
+    if (!gif) return '100%'
+    const gifHeight = getGifHeight(gif, width)
+    const heightPercentage = `${Math.round((gifHeight / width) * 100)}%`
+    return heightPercentage
 }

--- a/packages/react-components/stories/grid.stories.tsx
+++ b/packages/react-components/stories/grid.stories.tsx
@@ -86,6 +86,12 @@ const meta: Meta<typeof Grid> = {
         noLink: {
             control: { type: 'boolean' },
         },
+        columns: {
+            control: { type: 'number' },
+        },
+        gutter: {
+            control: { type: 'number' },
+        },
     },
     args: {
         noLink: false,


### PR DESCRIPTION
Restructure the element tree and css of the `Gif` component, allowing it to be more easily styled with a percentage. 

- Add the percentage prop
- remove redundant width and height from inner div
- remove redundant width and height from image 
- remove unnecessary wrapper of Container with React Component 

