### PR TITLE
react-components: use cilent added to barrel file

### DIFF
--- a/.changeset/poor-zoos-float.md
+++ b/.changeset/poor-zoos-float.md
@@ -1,0 +1,8 @@
+---
+'@giphy/react-components': patch
+---
+
+react-components: add 'use client' to barrel file (index.ts) in root of package
+so tsup doesn't treeshake it out
+
+See: https://github.com/egoist/tsup/issues/835

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { appendGiphySDKRequestHeader } from '@giphy/js-util'
 export { default as Attribution } from './components/attribution'
 export { default as AttributionOverlay } from './components/attribution/overlay'


### PR DESCRIPTION
tsup otherwise treeshakes it out in the esm build
some of our components don't need use client, but for now this works