### PR TITLE
Handle geo-blocked response from API

### DIFF
--- a/.changeset/cuddly-owls-divide.md
+++ b/.changeset/cuddly-owls-divide.md
@@ -1,0 +1,5 @@
+---
+'@giphy/js-fetch-api': minor
+---
+
+Handle geo-blocked response from API

--- a/packages/fetch-api/src/fetch-error.ts
+++ b/packages/fetch-api/src/fetch-error.ts
@@ -10,4 +10,6 @@ class FetchError extends Error {
     }
 }
 
+export class GeoFetchError extends FetchError {}
+
 export default FetchError

--- a/packages/fetch-api/src/index.ts
+++ b/packages/fetch-api/src/index.ts
@@ -2,7 +2,7 @@ import { appendGiphySDKRequestHeader, getGiphySDKRequestHeaders } from '@giphy/j
 
 export { default as GiphyFetch } from './api'
 export { serverUrl, setServerUrl } from './constants'
-export { default as FetchError } from './fetch-error'
+export { default as FetchError, GeoFetchError } from './fetch-error'
 export * from './option-types'
 export { gifPaginator } from './paginator'
 export { default as request } from './request'

--- a/packages/fetch-api/src/result-types.ts
+++ b/packages/fetch-api/src/result-types.ts
@@ -19,6 +19,7 @@ export interface Result {
 
 export interface ErrorResult {
     message?: string
+    meta?: ResultMeta
 }
 export interface GifResult extends Result {
     data: IGif


### PR DESCRIPTION
- Raise new error subclass `GeoFetchError` to differentiate a geo-blocked response from a regular 404 response