### PR TITLE
set a flag to ignore stop fetching

### DIFF
--- a/.changeset/kind-socks-relate.md
+++ b/.changeset/kind-socks-relate.md
@@ -1,0 +1,6 @@
+---
+'@giphy/react-components': minor
+'@giphy/js-fetch-api': minor
+---
+
+add a workaround for channels with hidden gifs

--- a/packages/react-components/src/components/carousel.tsx
+++ b/packages/react-components/src/components/carousel.tsx
@@ -112,7 +112,11 @@ class Carousel extends PureComponent<Props, State> {
                 this.setState({ isFetching: false })
             }
             if (gifs) {
-                if (existingGifs.length === gifs.length) {
+                // if we've just fetched and we don't have
+                // any more gifs, we're done fetching,
+                // unless we have a special flag
+                const skipCountCheck = !!(gifs as any)?.skipCountCheck
+                if (!skipCountCheck && existingGifs.length === gifs.length) {
                     this.setState({ isDoneFetching: true })
                 } else {
                     this.setState({ gifs, isFetching: false })

--- a/packages/react-components/src/components/grid.tsx
+++ b/packages/react-components/src/components/grid.tsx
@@ -115,17 +115,13 @@ class Grid extends PureComponent<Props, State> {
     onFetch = debounce(Grid.fetchDebounce, async () => {
         if (this.unmounted) return
         const { isFetching, isLoaderVisible } = this.state
-        const { externalGifs, fetchGifs } = this.props
+        const { externalGifs } = this.props
         const prefetchCount = (externalGifs || this.state.gifs).length
-        if (externalGifs) {
-            // reinitialize the paginator every fetch with the new external gifs
-            this.paginator = gifPaginator(fetchGifs, externalGifs)
-        }
         if (!isFetching && isLoaderVisible) {
             this.setState({ isFetching: true, isError: false })
             let gifs
             try {
-                gifs = await this.paginator()
+                gifs = await this.paginator(externalGifs)
                 if (this.unmounted) return
             } catch (error) {
                 if (this.unmounted) return
@@ -135,8 +131,10 @@ class Grid extends PureComponent<Props, State> {
             }
             if (gifs) {
                 // if we've just fetched and we don't have
-                // any more gifs, we're done fetching
-                if (prefetchCount === gifs.length) {
+                // any more gifs, we're done fetching,
+                // unless we have a special flag
+                const skipCountCheck = !!(gifs as any)?.skipCountCheck
+                if (!skipCountCheck && prefetchCount === gifs.length) {
                     this.setState({ isDoneFetching: true })
                 } else {
                     this.setState({ gifs, isFetching: false })


### PR DESCRIPTION
For channels endpoint, there can be gifs that are hidden by the user, but yet they still affect the offset value. This is a workaround to make another request at the offset in the `next` url provided by the channels endpoint. Using that offset lets us skip to the next available gif. 

This fix will only work with a fetch gifs function that parses the offset. We do that on giphy.com. This change won't work for other SDK users unless they implement the parsing of the offset. 

It's not a common issue and only affects a small number of channels so this shouldn't be a problem 