### PR TITLE
fix: log full video URL for unsupported playback errors

### DIFF
--- a/.changeset/bright-pugs-care.md
+++ b/.changeset/bright-pugs-care.md
@@ -1,0 +1,5 @@
+---
+'@giphy/react-components': patch
+---
+
+Log the full video URL for unsupported playback errors.

--- a/packages/react-components/src/components/video/util.ts
+++ b/packages/react-components/src/components/video/util.ts
@@ -9,7 +9,7 @@ export const getErrorMessage = (code: number, src = '') => {
         case 3:
             return 'Decode Error. An error of some description occurred while decoding the media resource, after the resource was established to be usable.'
         case 4:
-            return `Can not play a video of type "${src.split('.').pop()}" on this platform.`
+            return 'Can not play this video on this platform. Video URL: ' + src
         default:
             return ''
     }


### PR DESCRIPTION
## Summary
- log the full failing video URL for HTMLMediaElement unsupported playback errors
- replace the previous extension-only message, which was misleading when query params were present

## Testing
- not run